### PR TITLE
Fix pup download URL in auto-update workflow

### DIFF
--- a/.github/workflows/auto-update-csv.yml
+++ b/.github/workflows/auto-update-csv.yml
@@ -23,8 +23,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y curl gawk grep coreutils
           # Install pup (HTML parser)
-          wget https://github.com/ericchiang/pup/releases/download/v0.4.0/pup_0.4.0_linux_amd64.zip
-          unzip pup_0.4.0_linux_amd64.zip
+          PUP_VERSION="v0.4.0"
+          PUP_ARCHIVE="pup_${PUP_VERSION}_linux_amd64.zip"
+          wget "https://github.com/ericchiang/pup/releases/download/${PUP_VERSION}/${PUP_ARCHIVE}"
+          unzip "${PUP_ARCHIVE}"
           sudo mv pup /usr/local/bin/
           pup --version
 


### PR DESCRIPTION
## Summary
- update the auto-update workflow to download the correct pup v0.4.0 archive for linux
- keep the unzip and install steps aligned with the asset name so installation succeeds

## Testing
- ./scrape_lotto_results.sh
- ./generate_stats.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937f789921c83329dba5b57289cfb19)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the pup v0.4.0 Linux archive URL and unzip target in the auto-update workflow by parameterizing version and archive name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a04862a8fce8bc37cfeac51206243d869732815e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->