### PR TITLE
v2.1.2: certified portfolio probability objectives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,17 @@ jobs:
               }
               for strategy in ('coverage', 'anyPrizeBound', 'division4Bound', 'random')
           }
+          comparisons = {}
+          for name, metrics in result['comparisons'].items():
+              comparisons[name] = {}
+              for metric, values in metrics.items():
+                  comparisons[name][metric] = {
+                      'favourableMeanDifference': round(values['favourableMeanDifference'], 8),
+                      'ci95': [round(value, 8) for value in values['bootstrapMeanDifferenceCi95']],
+                      'probabilityOfSuperiority': round(values['probabilityOfSuperiority'], 6),
+                  }
           print('CERTIFIED_OBJECTIVE_SUMMARY=' + json.dumps(summary, sort_keys=True))
+          print('CERTIFIED_OBJECTIVE_COMPARISONS=' + json.dumps(comparisons, sort_keys=True))
           PY
       - name: Validate browser JavaScript
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,44 @@ jobs:
           python -m lotto_lab stats
           python -m json.tool assets/lotto_stats.json >/dev/null
           python -m json.tool assets/data_provenance.json >/dev/null
+      - name: Validate certified objective benchmark
+        env:
+          PYTHONPATH: src
+        run: |
+          python -m lotto_lab benchmark-objectives \
+            --count 10 \
+            --portfolios 12 \
+            --random-portfolios 48 \
+            --trials 4000 \
+            --seed 20260822 \
+            --candidates-per-ticket 320 \
+            --bootstrap-resamples 800 > /tmp/objectives.json
+          python -m json.tool /tmp/objectives.json >/dev/null
+          python - <<'PY'
+          import json
+
+          with open('/tmp/objectives.json', encoding='utf-8') as handle:
+              result = json.load(handle)
+          assert result['divisionOneProbabilityEqual'] is True
+          for strategy in ('coverage', 'anyPrizeBound', 'division4Bound', 'random'):
+              assert strategy in result['strategies']
+          summary = {
+              strategy: {
+                  'anyPrizeRate': round(result['strategies'][strategy]['anyPrizeRate']['mean'], 6),
+                  'anyPrizeLowerBound': round(
+                      result['strategies'][strategy]['anyPrizeBonferroniLowerBound']['mean'], 6
+                  ),
+                  'division4Rate': round(
+                      result['strategies'][strategy]['division4OrBetterRate']['mean'], 6
+                  ),
+                  'division4GlobalOptimalRate': round(
+                      result['strategies'][strategy]['division4GloballyOptimal']['mean'], 4
+                  ),
+              }
+              for strategy in ('coverage', 'anyPrizeBound', 'division4Bound', 'random')
+          }
+          print('CERTIFIED_OBJECTIVE_SUMMARY=' + json.dumps(summary, sort_keys=True))
+          PY
       - name: Validate browser JavaScript
         run: |
           node --check assets/app.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,27 @@ jobs:
           for name, metrics in result['comparisons'].items():
               comparisons[name] = {}
               for metric, values in metrics.items():
+                  if values.get('inferenceSuppressed'):
+                      comparisons[name][metric] = {
+                          'inferenceSuppressed': True,
+                          'exactProbabilityDifference': values['exactProbabilityDifference'],
+                          'descriptiveSimulatedMeanDifference': round(
+                              values['descriptiveSimulatedMeanDifference'], 8
+                          ),
+                          'reason': values['reason'],
+                      }
+                      continue
                   comparisons[name][metric] = {
+                      'inferenceSuppressed': False,
                       'favourableMeanDifference': round(values['favourableMeanDifference'], 8),
                       'ci95': [round(value, 8) for value in values['bootstrapMeanDifferenceCi95']],
                       'probabilityOfSuperiority': round(values['probabilityOfSuperiority'], 6),
                   }
+          suppressed = result['comparisons']['division4BoundVsCoverage']['division4OrBetterRate']
+          assert suppressed['inferenceSuppressed'] is True
+          assert suppressed['exactProbabilityDifference'] == 0.0
+          assert suppressed['bootstrapMeanDifferenceCi95'] is None
+          assert suppressed['probabilityOfSuperiority'] is None
           print('CERTIFIED_OBJECTIVE_SUMMARY=' + json.dumps(summary, sort_keys=True))
           print('CERTIFIED_OBJECTIVE_COMPARISONS=' + json.dumps(comparisons, sort_keys=True))
           PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
         run: |
           node --check assets/app.js
           node --check assets/benchmark.js
+          node --check assets/certificates.js
           node --check service-worker.js
       - name: Validate static site references
         run: |
@@ -48,6 +49,7 @@ jobs:
           test -f assets/app.js
           test -f assets/benchmark.css
           test -f assets/benchmark.js
+          test -f assets/certificates.js
           test -f assets/lotto_stats.json
           test -f assets/data_provenance.json
           test -f assets/site.webmanifest
@@ -57,5 +59,8 @@ jobs:
           grep -q 'assets/site.webmanifest' index.html
           grep -q 'assets/benchmark.css' benchmark.html
           grep -q 'assets/benchmark.js' benchmark.html
+          grep -q 'assets/certificates.js' benchmark.html
+          grep -q 'id="certificates"' benchmark.html
+          grep -q 'assets/certificates.js' service-worker.js
           grep -q 'benchmark.html' service-worker.js
           grep -q 'service-worker.js' assets/app.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 2.1.2 — Certified portfolio objectives
+
+### Added
+
+- exact two-ticket intersection counts/probabilities for `>=k` main-number events;
+- rigorous second-order Bonferroni lower bounds for portfolio union probabilities;
+- exact/global-optimality certificates when target ticket events are pairwise disjoint;
+- proof-backed Division-4-or-better certificate: max pairwise ticket overlap `<=1` makes `>=4 main` events disjoint;
+- `any-prize-bound` ticket mode, which greedily minimises exact pairwise `>=3 main` event-intersection cost;
+- `division4-bound` ticket mode, which minimises exact pairwise `>=4 main` intersections and reports when the global optimum is reached;
+- `lotto-lab benchmark-objectives` for coverage vs any-prize-bound vs Division-4-bound vs QuickPick;
+- probability certificates in ticket metrics and generated reference coverage-set statistics;
+- Certified Probability panel in Benchmark Lab;
+- tests for exact intersection counts, Bonferroni behaviour and the Division-4 global-optimality theorem.
+
+### Research finding / guardrail
+
+- a prototype that directly trained ticket selection on simulated any-prize outcomes overfit its training draw sample and failed to improve on the existing coverage design out of sample;
+- that sampled-training optimiser is not shipped as a recommended strategy;
+- a Bonferroni lower bound is never presented as an exact union probability unless disjointness conditions prove exactness;
+- Division 1 remains exactly equal for same-sized sets of distinct standard games.
+
 ## 2.1.1 — Multi-seed benchmark
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,12 +17,70 @@ possible standard six-number combinations. Therefore one standard game has Divis
 Number selection cannot improve that probability if the draw is fair. Objective optimisation instead falls into three separate categories:
 
 1. **Own more distinct combinations** — the only direct Division 1 probability increase.
-2. **Reduce portfolio redundancy** — for a fixed number of games, maximise unique pairs, triples and quadruples so multiple tickets overlap less at lower orders.
+2. **Reduce portfolio redundancy** — structure multiple games so their lower-tier winning events overlap less.
 3. **Conditional prize-sharing research** — experimentally avoid patterns people may choose disproportionately. This does not improve the chance of being drawn; it may matter only to how many people share a pari-mutuel prize if that combination wins.
 
-See [`docs/ODDS_OPTIMISATION.md`](docs/ODDS_OPTIMISATION.md) for the claim hierarchy and limitations.
+See [`docs/ODDS_OPTIMISATION.md`](docs/ODDS_OPTIMISATION.md) and [`docs/BENCHMARKING.md`](docs/BENCHMARKING.md) for the claim hierarchy and limitations.
 
-## v2.1 highlights
+## v2.1.2 highlights
+
+### Exact portfolio probability certificates
+
+v2.1.2 adds exact two-ticket event-intersection combinatorics and portfolio certificates.
+
+For a portfolio event such as “at least one game matches three or more main numbers”, the code computes the exact first- and second-order terms:
+
+```text
+S1 = sum P(Ai)
+S2 = sum P(Ai ∩ Aj)
+
+P(any event) >= max(0, S1 - S2)
+```
+
+This is a rigorous Bonferroni lower bound, not a simulation estimate.
+
+For **Division 4 or better**, there is a stronger exact result. If every pair of six-number games shares at most one number, two games cannot both match four or more of the same six winning main numbers. Their `>=4 main` events are pairwise disjoint, so:
+
+```text
+P(Division 4 or better somewhere in portfolio)
+  = ticket_count × P(one game matches >=4 main)
+```
+
+That reaches the universal sum-of-marginals upper bound, so the portfolio is **globally optimal for Division 4-or-better probability at that ticket count**.
+
+### Separate ticket objectives
+
+The CLI now keeps distinct objectives separate instead of pretending one heuristic is universally best:
+
+- `coverage` — generic quadruple → triple → pair subset diversity;
+- `any-prize-bound` — greedily minimises exact pairwise `>=3 main` event-intersection cost, improving the rigorous second-order any-prize lower bound;
+- `division4-bound` — minimises exact pairwise `>=4 main` event intersections and can return a global-optimality certificate;
+- `random` — uniform QuickPick baseline;
+- `anti-crowding` — experimental conditional prize-sharing research only.
+
+Every generated portfolio reports probability certificates in `ticket_metrics`.
+
+### A rejected optimiser is also a result
+
+A direct prototype trained ticket selection on simulated any-prize outcomes. It performed very strongly on its training draws but failed to improve on the existing coverage design on held-out draws.
+
+That sampled-training optimiser is **not shipped as a recommended strategy**. The project records this negative result explicitly so future work does not reintroduce training-sample overfitting as an apparent lottery edge.
+
+### Multi-seed benchmark
+
+v2.1.1 replaced the weak “one coverage seed vs one QuickPick seed” inference with a distribution benchmark:
+
+- independently seeded coverage portfolios;
+- a larger distribution of independently seeded QuickPick portfolios;
+- the same simulated draw sample applied to every portfolio;
+- 5th/25th/50th/75th/95th percentile summaries;
+- probability-of-superiority;
+- bootstrap 95% intervals for favourable mean strategy differences;
+- fixed reference seeds and sample sizes documented in [`docs/BENCHMARKING.md`](docs/BENCHMARKING.md).
+
+v2.1.2 adds a separate `benchmark-objectives` command to compare generic coverage, any-prize-bound, Division-4-bound and QuickPick portfolios on held-out shared draws.
+
+Equal-size sets of distinct games always have **identical Division 1 probability**.
 
 ### Exact probability engine
 
@@ -30,50 +88,10 @@ See [`docs/ODDS_OPTIMISATION.md`](docs/ODDS_OPTIMISATION.md) for the claim hiera
 - cumulative probability across repeated independent draws;
 - System 6–20 equivalence via `C(k, 6)` standard combinations;
 - exact 0–6 main-number match distribution;
-- exact Division 1–6 standard-game probabilities under the current 6 winning + 2 supplementary rules;
-- exact overall standard-game any-prize probability.
-
-### Combinatorial portfolio optimiser
-
-`coverage` mode searches candidate games and prioritises:
-
-1. new four-number subsets;
-2. new three-number subsets;
-3. new pairs;
-4. lower maximum game-to-game overlap;
-5. balanced number usage.
-
-The result is measurable with pair/triple/quadruple coverage efficiency. It is a portfolio-structure optimisation, not a prediction model.
-
-### Multi-seed benchmark
-
-v2.1.1 replaces the weak “one coverage seed vs one QuickPick seed” inference with a distribution benchmark:
-
-- independently seeded coverage portfolios;
-- a larger distribution of independently seeded QuickPick portfolios;
-- the same simulated draw sample applied to every portfolio;
-- 5th/25th/50th/75th/95th percentile summaries;
-- probability-of-superiority;
-- bootstrap 95% intervals for the favourable mean strategy difference;
-- fixed reference seeds and sample sizes documented in [`docs/BENCHMARKING.md`](docs/BENCHMARKING.md).
-
-Equal-size sets of distinct games still have **identical Division 1 probability**. The benchmark measures lower-division portfolio diversification.
-
-A dedicated static [`benchmark.html`](benchmark.html) page can also run a smaller exploratory benchmark locally in the browser.
-
-### Evidence layer
-
-- Monte Carlo portfolio evaluation with actual Saturday Lotto prize divisions;
-- Wilson 95% confidence intervals;
-- leakage-free walk-forward comparison against historical draws;
-- multi-seed distribution benchmarking rather than a single baseline seed;
-- explicit effect-size and uncertainty labels.
-
-### Experimental anti-crowding mode
-
-The optional anti-crowding generator penalises birthday-heavy games, number 7, consecutive pairs and very evenly spaced selections. It is based on published evidence that lottery players make non-uniform choices, but it is **not calibrated to Australian Saturday Lotto player-level ticket data**.
-
-It must never be interpreted as increasing draw probability.
+- exact Division 1–6 standard-game probabilities;
+- exact overall standard-game any-prize probability;
+- exact two-ticket `>=k main` event-intersection probabilities;
+- rigorous portfolio union lower bounds and exact disjoint-event certificates.
 
 ### Data integrity
 
@@ -93,7 +111,7 @@ The GitHub Pages site includes:
 - System 6–20 calculator;
 - exact prize-division table;
 - main-match distribution;
-- upgraded Ticket Lab with coverage, QuickPick and experimental anti-crowding modes;
+- Ticket Lab with coverage, QuickPick and experimental anti-crowding modes;
 - pair/triple/quadruple coverage metrics;
 - local portfolio any-prize simulation with confidence interval;
 - shareable ticket-set URLs and CSV export;
@@ -102,6 +120,7 @@ The GitHub Pages site includes:
 - accessible keyboard frequency chart;
 - data freshness and provenance display;
 - dedicated Benchmark Lab with client-side multi-seed runs and JSON export;
+- **Certified Probability** panel separating exact bounds from simulated evidence;
 - system/light/dark themes;
 - offline/PWA cache support.
 
@@ -121,10 +140,13 @@ Run with the source tree:
 PYTHONPATH=src python -m lotto_lab validate
 PYTHONPATH=src python -m lotto_lab stats
 PYTHONPATH=src python -m lotto_lab tickets --count 10 --mode coverage
+PYTHONPATH=src python -m lotto_lab tickets --count 10 --mode any-prize-bound --json
+PYTHONPATH=src python -m lotto_lab tickets --count 10 --mode division4-bound --json
 PYTHONPATH=src python -m lotto_lab tickets --count 10 --mode random
 PYTHONPATH=src python -m lotto_lab tickets --count 10 --mode anti-crowding
 PYTHONPATH=src python -m lotto_lab simulate --count 10 --trials 50000
 PYTHONPATH=src python -m lotto_lab benchmark --count 10 --coverage-portfolios 50 --random-portfolios 200 --trials 5000
+PYTHONPATH=src python -m lotto_lab benchmark-objectives --count 10 --portfolios 24 --random-portfolios 96 --trials 5000
 PYTHONPATH=src python -m lotto_lab backtest --count 10 --steps 120
 PYTHONPATH=src python -m lotto_lab verify-secondary --latest 10
 ```
@@ -139,7 +161,7 @@ The scheduled workflow runs after the Saturday draw. It:
 2. determines whether draw data or generated assets need rebuilding;
 3. cross-checks the newest draws against an independent source;
 4. stops on disagreement;
-5. rebuilds schema-v3 statistics, reference evidence and SHA-256 provenance;
+5. rebuilds schema-v3 statistics, reference evidence, probability certificates and SHA-256 provenance;
 6. commits only verified changes directly to `main`.
 
 It does not create recurring update branches or automated pull requests.
@@ -153,6 +175,7 @@ ruff check src tests
 PYTHONPATH=src python -m unittest discover -s tests -v
 node --check assets/app.js
 node --check assets/benchmark.js
+node --check assets/certificates.js
 node --check service-worker.js
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,6 +24,10 @@ This is the living engineering/research tracker. The governing rule is: **improv
 - [x] Exact 0–6 main-number match distribution.
 - [x] Exact Division 1–6 standard-game probabilities.
 - [x] Exact any-prize probability for a standard game.
+- [x] Exact two-ticket intersection probability for any ≥k-main event.
+- [x] Rigorous portfolio Bonferroni lower bound `S1 - S2` from exact pair intersections.
+- [x] Exact global-optimality certificate when portfolio events are pairwise disjoint.
+- [x] Prove that max pairwise game overlap ≤1 makes Division-4-or-better events pairwise disjoint.
 
 ### Better portfolio construction
 
@@ -32,8 +36,12 @@ This is the living engineering/research tracker. The governing rule is: **improv
 - [x] Report subset placement count, unique count, repeats, efficiency and universe coverage.
 - [x] Retain distinct-combination and overlap guarantees.
 - [x] Compare optimiser performance against a **distribution** of independently seeded random portfolios.
+- [x] Add an any-prize-bound objective that minimises exact pair-event intersection cost.
+- [x] Add a Division-4-bound objective that can return a global-optimality certificate.
+- [x] Keep generic subset-diversity coverage as a separate objective rather than silently replacing it.
 - [ ] Benchmark greedy search against local search / simulated annealing / integer programming for useful ticket-count ranges.
-- [ ] Add objective selector: maximise any-prize probability, ≥4-main coverage, or generic subset diversity.
+- [ ] Investigate exact or higher-order optimisation of the any-prize union beyond the second-order Bonferroni bound.
+- [ ] Determine useful ticket-count ranges where a pairwise-disjoint ≥4-main packing can be constructed reliably.
 
 ### Evidence
 
@@ -45,6 +53,8 @@ This is the living engineering/research tracker. The governing rule is: **improv
 - [x] Pre-register fixed benchmark seeds/ticket counts in `docs/BENCHMARKING.md`.
 - [x] Add probability-of-superiority and random-baseline quantiles.
 - [x] Use shared simulated draws across portfolio distributions to reduce comparison noise.
+- [x] Add objective benchmark: subset coverage vs any-prize-bound vs Division-4-bound vs QuickPick.
+- [x] Reject direct simulated-training optimisation after held-out prototypes overfit and failed to improve on coverage.
 - [ ] Add nested resampling so strategy-difference uncertainty includes both portfolio-seed and draw-sample uncertainty.
 - [ ] Add benchmark regression thresholds only after enough releases establish stable expected ranges.
 
@@ -86,6 +96,7 @@ This is the living engineering/research tracker. The governing rule is: **improv
 - [x] Static-site integration tests.
 - [x] Dedicated Benchmark Lab page with local multi-seed exploratory runs and JSON export.
 - [x] PWA shortcut to the Benchmark Lab.
+- [x] Certified Probability panel separating exact bounds from Monte Carlo evidence.
 - [ ] Add richer accessible SVG charts and comparison views.
 - [ ] Add explicit PWA install/update UI.
 - [ ] Add Playwright browser smoke tests on a stable CI runner.
@@ -115,4 +126,6 @@ This is the living engineering/research tracker. The governing rule is: **improv
 - Do **not** mix anti-crowding / payout-sharing research into the probability of a combination being drawn.
 - Do **not** claim a strategy advantage from one random seed, one backtest window or overlapping confidence intervals.
 - Do **not** call probability-of-superiority the probability that a strategy wins the lottery.
+- Do **not** train an optimiser on simulated draws and report its training performance as evidence; use held-out evaluation and reject it if it fails to generalise.
+- Do **not** describe a Bonferroni lower bound as the exact union probability unless the event intersections required for exactness have been proved absent.
 - Do **not** encourage higher spend; probability-vs-spend tools must show both sides of the trade-off.

--- a/assets/certificates.js
+++ b/assets/certificates.js
@@ -1,0 +1,65 @@
+(() => {
+  const nf = new Intl.NumberFormat('en-AU');
+  const pct = (value, digits = 3) =>
+    new Intl.NumberFormat('en-AU', {
+      style: 'percent',
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    }).format(Number(value) || 0);
+
+  const setText = (id, value) => {
+    const element = document.getElementById(id);
+    if (element) element.textContent = value;
+  };
+
+  function renderPending() {
+    setText('cert-any-lower', 'Pending stats refresh');
+    setText('cert-any-upper', '—');
+    setText('cert-d4-exact', 'Pending stats refresh');
+    setText('cert-d4-status', '—');
+    setText('cert-overlap', '—');
+  }
+
+  function renderCertificates(stats) {
+    const metrics = stats?.referenceCoverageSet?.metrics;
+    const certificates = metrics?.probabilityCertificates;
+    if (!certificates) {
+      renderPending();
+      return;
+    }
+
+    const anyPrize = certificates.anyPrize;
+    const division4 = certificates.division4OrBetter;
+    setText('cert-any-lower', pct(anyPrize.bonferroniLowerBound, 3));
+    setText('cert-any-upper', `Union upper bound ${pct(anyPrize.firstOrderUnionBound, 3)}`);
+    setText(
+      'cert-d4-exact',
+      division4.exactProbability == null ? 'Not exact' : pct(division4.exactProbability, 4),
+    );
+    setText(
+      'cert-d4-status',
+      division4.globallyOptimalForTicketCount
+        ? 'Certified global optimum for this game count'
+        : 'Lower bound only; pairwise event intersections remain',
+    );
+    setText('cert-overlap', `${nf.format(metrics.maxPairwiseOverlap)} shared number${metrics.maxPairwiseOverlap === 1 ? '' : 's'}`);
+
+    const badge = document.getElementById('cert-d4-badge');
+    if (badge) {
+      badge.textContent = division4.globallyOptimalForTicketCount ? 'PROVED OPTIMAL' : 'BOUND ONLY';
+    }
+  }
+
+  async function load() {
+    try {
+      const response = await fetch('assets/lotto_stats.json', { cache: 'no-store' });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      renderCertificates(await response.json());
+    } catch (error) {
+      console.warn('probability certificates unavailable', error);
+      renderPending();
+    }
+  }
+
+  load();
+})();

--- a/benchmark.html
+++ b/benchmark.html
@@ -5,13 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
   <meta name="theme-color" content="#07101f">
-  <meta name="description" content="Multi-seed portfolio benchmark for Saturday Lotto coverage portfolios versus QuickPick distributions.">
+  <meta name="description" content="Multi-seed and certified portfolio probability evidence for Saturday Lotto.">
   <title>Benchmark Lab · Saturday Lotto Probability Lab</title>
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="manifest" href="assets/site.webmanifest">
   <link rel="stylesheet" href="assets/app.css">
   <link rel="stylesheet" href="assets/benchmark.css">
   <script defer src="assets/benchmark.js"></script>
+  <script defer src="assets/certificates.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -26,6 +27,7 @@
     </a>
     <nav class="header-nav" aria-label="Benchmark navigation">
       <a href="index.html#tickets">Ticket Lab</a>
+      <a href="#certificates">Certificates</a>
       <a href="#evidence">Benchmark</a>
       <a href="index.html#diagnostics">Diagnostics</a>
       <a href="https://github.com/JDsnyke/saturday-tatts-lotto-scraper/blob/main/ROADMAP.md">Roadmap</a>
@@ -38,17 +40,18 @@
   <main id="main">
     <section class="hero section-shell">
       <div class="hero-copy">
-        <div class="eyebrow"><span class="status-dot"></span> Portfolio distributions · shared draws</div>
-        <h1>Stop comparing<br><span>one lucky seed.</span></h1>
-        <p class="hero-lead">A single coverage portfolio beating a single QuickPick portfolio can happen by chance. Benchmark Lab compares independently seeded portfolio distributions on the same simulated draw sample and reports effect size, uncertainty and probability-of-superiority.</p>
+        <div class="eyebrow"><span class="status-dot"></span> Portfolio distributions · exact certificates</div>
+        <h1>Separate what is<br><span>estimated from proved.</span></h1>
+        <p class="hero-lead">Benchmark Lab now combines multi-seed simulation with exact portfolio certificates. Division 1 remains fixed by the number of distinct games; lower-tier portfolio structure can be bounded or, in important cases, solved exactly.</p>
         <div class="hero-actions">
-          <a class="button primary" href="#evidence">Open benchmark <span aria-hidden="true">→</span></a>
+          <a class="button primary" href="#certificates">View certificates <span aria-hidden="true">→</span></a>
+          <a class="button secondary" href="#evidence">Open benchmark</a>
           <a class="button secondary" href="index.html">Back to main lab</a>
         </div>
         <div class="principle-strip" aria-label="Benchmark principles">
-          <span><b>01</b> Independent portfolio seeds</span>
-          <span><b>02</b> Common simulated draws</span>
-          <span><b>03</b> Bootstrap uncertainty</span>
+          <span><b>01</b> Exact combinatorics</span>
+          <span><b>02</b> Rigorous union bounds</span>
+          <span><b>03</b> Independent portfolio seeds</span>
           <span><b>04</b> Div 1 held equal</span>
         </div>
       </div>
@@ -71,9 +74,41 @@
     <section class="section-shell thesis" role="note">
       <div class="thesis-mark" aria-hidden="true">Δ</div>
       <div>
-        <span class="eyebrow">How to read the benchmark</span>
+        <span class="eyebrow">How to read the evidence</span>
         <h2>A positive lower-division effect is a portfolio result, not a forecasting edge.</h2>
-        <p>Triple and quadruple coverage are exact structural measures. Prize-hit rates are Monte Carlo estimates. Bootstrap intervals describe variability across independently seeded portfolios conditional on the shared simulated draw sample.</p>
+        <p>Pair, triple and quadruple coverage are exact structural measures. Probability certificates are exact combinatorics. Prize-hit rates are Monte Carlo estimates. Each claim is labelled according to what it can actually prove.</p>
+      </div>
+    </section>
+
+    <section class="section-shell" id="certificates">
+      <div class="section-heading">
+        <div><span class="eyebrow">Certified Probability</span><h2>Bounds that do not depend on simulation luck</h2></div>
+        <p>The reference coverage portfolio is analysed using exact two-ticket event intersections. Any-prize receives a rigorous second-order Bonferroni lower bound. Division 4-or-better becomes exact whenever all ≥4-main ticket events are pairwise disjoint.</p>
+      </div>
+      <div class="planner-kpis">
+        <article class="result-card glass">
+          <span>Any-prize certified lower bound</span>
+          <strong id="cert-any-lower">Loading…</strong>
+          <small id="cert-any-upper">Exact Bonferroni S1 − S2</small>
+        </article>
+        <article class="result-card glass accent">
+          <div class="console-head"><span>Division 4+ probability</span><span class="badge" id="cert-d4-badge">CHECKING</span></div>
+          <strong id="cert-d4-exact">Loading…</strong>
+          <small id="cert-d4-status">Checking pairwise event intersections…</small>
+        </article>
+        <article class="result-card glass">
+          <span>Maximum ticket overlap</span>
+          <strong id="cert-overlap">Loading…</strong>
+          <small>≤1 makes ≥4-main events mutually exclusive in pairs</small>
+        </article>
+      </div>
+      <div class="research-note glass" style="margin-top:14px">
+        <div><span class="research-icon" aria-hidden="true">✓</span></div>
+        <div>
+          <span class="eyebrow">Exact theorem</span>
+          <h3>If every pair of games shares at most one number, Division 4-or-better is globally maximised.</h3>
+          <p>For two six-number games sharing at most one number to both match at least four winning main numbers, the draw would need at least seven distinct winning numbers. Saturday Lotto draws only six winning main numbers. Their ≥4-main events therefore cannot occur together. The portfolio union equals the sum of its single-game probabilities, which is also the universal union upper bound.</p>
+        </div>
       </div>
     </section>
 
@@ -93,14 +128,14 @@
     </section>
 
     <section class="section-shell method-section">
-      <div class="section-heading"><div><span class="eyebrow">Method</span><h2>What this improves over v2.1</h2></div><p>The old reference comparison used one seeded portfolio per strategy. The new benchmark estimates distributions and strategy differences across many seeds.</p></div>
+      <div class="section-heading"><div><span class="eyebrow">Method</span><h2>Exact mathematics first, simulation second</h2></div><p>The evidence hierarchy now distinguishes rigorous probability bounds from Monte Carlo estimates and descriptive structural metrics.</p></div>
       <div class="method-grid">
-        <article class="method-card"><span class="method-number">01</span><span class="claim exact">Exact</span><h3>Structural coverage</h3><p>Pair, triple and quadruple efficiency is counted directly for every portfolio.</p></article>
-        <article class="method-card"><span class="method-number">02</span><span class="claim simulated">Simulated</span><h3>Shared draws</h3><p>Every portfolio sees the same draw sample, reducing irrelevant Monte Carlo noise in comparisons.</p></article>
-        <article class="method-card"><span class="method-number">03</span><span class="claim simulated">Bootstrap</span><h3>Mean difference interval</h3><p>Portfolio distributions are resampled to estimate a 95% interval for the favourable mean difference.</p></article>
-        <article class="method-card"><span class="method-number">04</span><span class="claim descriptive">Effect</span><h3>Probability-of-superiority</h3><p>Pairwise distribution comparison shows how consistently one strategy beats the other on a metric.</p></article>
-        <article class="method-card"><span class="method-number">05</span><span class="claim guardrail">Invariant</span><h3>Division 1 equality</h3><p>Equal-size sets of distinct standard games always retain identical Division 1 probability.</p></article>
-        <article class="method-card"><span class="method-number">06</span><span class="claim guardrail">Next</span><h3>Optimiser benchmark</h3><p>The roadmap next compares greedy coverage against local-search and optimisation alternatives.</p></article>
+        <article class="method-card"><span class="method-number">01</span><span class="claim exact">Exact</span><h3>Pair intersections</h3><p>Two-ticket ≥3-main and ≥4-main event intersections are counted exactly from the shared, ticket-only and outside ball groups.</p></article>
+        <article class="method-card"><span class="method-number">02</span><span class="claim exact">Certified</span><h3>Bonferroni lower bound</h3><p>S1 − S2 gives a rigorous lower bound for the probability that at least one portfolio game reaches the selected match threshold.</p></article>
+        <article class="method-card"><span class="method-number">03</span><span class="claim exact">Optimal</span><h3>Division 4+ certificate</h3><p>If pairwise ≥4-main intersections are zero, the exact union reaches the universal sum-of-marginals upper bound.</p></article>
+        <article class="method-card"><span class="method-number">04</span><span class="claim simulated">Simulated</span><h3>Shared draws</h3><p>Every benchmark portfolio sees the same draw sample, reducing irrelevant Monte Carlo noise in comparisons.</p></article>
+        <article class="method-card"><span class="method-number">05</span><span class="claim descriptive">Effect</span><h3>Probability-of-superiority</h3><p>Pairwise distribution comparison shows how consistently one strategy beats another on a named benchmark metric.</p></article>
+        <article class="method-card"><span class="method-number">06</span><span class="claim guardrail">Rejected</span><h3>No simulated-training optimiser</h3><p>A prototype trained directly on sampled draws overfit its training sample and did not generalise. It is not shipped as a recommended strategy.</p></article>
       </div>
     </section>
   </main>

--- a/docs/BENCHMARKING.md
+++ b/docs/BENCHMARKING.md
@@ -1,36 +1,133 @@
-# Multi-seed portfolio benchmarking
+# Multi-seed and certified portfolio benchmarking
 
-This document defines the benchmark used to compare the combinatorial coverage generator with uniform random QuickPick portfolios.
+This document defines the evidence framework used to compare Saturday Lotto portfolio generators.
 
-## Question
+The project separates three kinds of evidence:
 
-For the **same number of distinct standard games**, does the coverage generator produce measurably different lower-division portfolio structure and simulated outcomes than a distribution of uniform random portfolios?
+1. **exact combinatorics and certificates**;
+2. **structural portfolio metrics**;
+3. **out-of-sample Monte Carlo comparisons**.
 
-It does **not** test whether one set of numbers is more likely to be drawn. Equal-size sets of distinct standard games have the same Division 1 probability:
+None of these changes the probability of an individual six-number combination being drawn.
+
+## Division 1 invariant
+
+For the same number of distinct standard games, every portfolio has identical Division 1 probability:
 
 ```text
 ticket_count / C(45, 6)
 ```
 
-## Why the old comparison was insufficient
+The benchmark therefore studies only lower-division portfolio overlap and coverage.
 
-A comparison between one coverage seed and one QuickPick seed can be dominated by ordinary seed-to-seed variation. A strategy should not be described as structurally better because it beat one baseline portfolio.
+## Exact event-intersection mathematics
 
-The multi-seed benchmark therefore compares **portfolio distributions**.
+For two six-number tickets sharing `r` numbers, the 45 balls can be partitioned into:
 
-## Reference design
+- `r` shared numbers;
+- `6-r` numbers unique to ticket A;
+- `6-r` numbers unique to ticket B;
+- `33+r` numbers in neither ticket.
 
-The generated statistics asset uses a fixed, reproducible reference benchmark:
+For a threshold `k`, the code sums all six-main-number draws in which both tickets match at least `k` numbers. This gives the **exact pair-event intersection probability**.
+
+For the any-prize event, `k=3` because every current Saturday Lotto prize division requires at least three winning main numbers. For Division 4 or better, `k=4`.
+
+Known exact intersection counts for selected cases include:
+
+```text
+>=3 main, overlap 0: 400 winning-main sets
+>=3 main, overlap 1: 3,700 winning-main sets
+>=4 main, overlap 0: 0
+>=4 main, overlap 1: 0
+>=4 main, overlap 2: 36
+```
+
+Each count is divided by `C(45,6)` to obtain its probability.
+
+## Bonferroni portfolio lower bound
+
+For portfolio events `A1 ... An`, the code computes:
+
+```text
+S1 = sum P(Ai)
+S2 = sum P(Ai ∩ Aj), i < j
+
+P(A1 ∪ ... ∪ An) >= max(0, S1 - S2)
+```
+
+This is a rigorous second-order Bonferroni lower bound.
+
+For the any-prize objective, this bound is useful because exact pairwise overlap is a major source of portfolio redundancy. It is still a **lower bound**, not the exact union probability unless additional intersection structure is proved absent.
+
+## Exact Division-4-or-better certificate
+
+If every pair of portfolio tickets shares at most one number, their `>=4 main` events are pairwise disjoint.
+
+Reason: two six-number tickets with overlap at most one would require at least
+
+```text
+4 + 4 - 1 = 7
+```
+
+distinct winning main numbers for both to match four or more. Saturday Lotto draws only six winning main numbers.
+
+Therefore, for such a portfolio:
+
+```text
+P(at least one ticket matches >=4 main)
+  = ticket_count * P(one ticket matches >=4 main)
+```
+
+The right-hand side is also the universal union upper bound. The portfolio is therefore **globally optimal for Division 4-or-better probability at that ticket count**.
+
+This is an exact theorem, not a simulation result.
+
+## Ticket objectives
+
+The CLI exposes separate generation modes because they optimise different things:
+
+- `coverage` — generic quadruple → triple → pair subset diversity;
+- `any-prize-bound` — minimises exact pairwise `>=3 main` event-intersection cost, thereby maximising the second-order any-prize lower bound greedily;
+- `division4-bound` — minimises exact `>=4 main` pair-event intersection cost, then uses the any-prize pair cost and structural coverage as tie-breakers;
+- `random` — uniform QuickPick baseline;
+- `anti-crowding` — experimental conditional prize-sharing research only.
+
+Example:
+
+```bash
+PYTHONPATH=src python -m lotto_lab tickets --count 10 --mode any-prize-bound --json
+PYTHONPATH=src python -m lotto_lab tickets --count 10 --mode division4-bound --json
+```
+
+The JSON metrics include both any-prize and Division-4-or-better probability certificates.
+
+## Why sampled-training optimisation was rejected
+
+A prototype directly selected tickets by maximising any-prize hits on a simulated training draw sample.
+
+Held-out experiments showed a large training/validation gap and no improvement over the existing coverage design. The reason is intuitive: marginal differences between strong portfolios are small compared with sampling noise, so a finite training sample can reward lucky candidate tickets rather than genuinely better structure.
+
+That optimiser is **not shipped as a recommended strategy**.
+
+Any future stochastic optimiser must:
+
+- use separate training and validation draw samples;
+- report the training/validation gap;
+- beat the existing structural baseline out of sample;
+- avoid describing training performance as evidence.
+
+## Multi-seed coverage benchmark
+
+The generated statistics asset keeps the fixed v2.1.1 reference benchmark for reproducibility:
 
 - 10 standard games per portfolio;
 - 32 independently seeded coverage portfolios;
 - 128 independently seeded QuickPick portfolios;
 - 2,500 shared simulated main-number draws;
-- fixed root seed `20260822`;
-- 120 candidate games considered per greedy coverage step;
-- 1,200 bootstrap resamples for the mean-difference interval.
-
-CLI defaults are larger and can be changed by the caller.
+- root seed `20260822`;
+- 120 candidate games per coverage step;
+- 1,200 bootstrap resamples.
 
 ```bash
 PYTHONPATH=src python -m lotto_lab benchmark \
@@ -41,43 +138,50 @@ PYTHONPATH=src python -m lotto_lab benchmark \
   --seed 20260822
 ```
 
-## Common random numbers
+The fixed reference design is intentionally not silently changed when new objective modes are added. That preserves release-to-release comparability.
 
-Every portfolio in a benchmark run is evaluated on the same simulated draw sample.
+## Certified-objective benchmark
 
-This is a standard variance-reduction idea: differences caused purely by one strategy seeing an easier random draw sample are removed. Portfolio-seed variation remains, which is exactly what the benchmark is intended to measure.
+The additional objective benchmark compares:
 
-## Structural metrics
+- generic subset coverage;
+- any-prize-bound portfolios;
+- Division-4-bound portfolios;
+- QuickPick portfolios.
 
-These are counted exactly for each generated portfolio:
+All strategies are evaluated on the same simulated draw sample. The bound-driven generators themselves do **not** train on those simulated outcomes; their objectives come from exact pair-event combinatorics.
 
-- pair coverage efficiency;
-- triple coverage efficiency;
-- quadruple coverage efficiency;
-- maximum pairwise ticket overlap;
-- unique numbers represented.
-
-Coverage efficiency is:
-
-```text
-unique covered subsets / total subset placements
+```bash
+PYTHONPATH=src python -m lotto_lab benchmark-objectives \
+  --count 10 \
+  --portfolios 24 \
+  --random-portfolios 96 \
+  --trials 5000 \
+  --seed 20260822 \
+  --candidates-per-ticket 320
 ```
 
-A value of `1.0` means no repeated subset placements at that order.
+Reported metrics include:
 
-## Outcome metrics
+- any-prize Bonferroni lower bound;
+- simulated any-prize rate;
+- certified Division-4-or-better probability;
+- simulated Division-4-or-better rate;
+- proportion of portfolios receiving the exact global-optimality certificate;
+- triple coverage efficiency;
+- maximum pairwise overlap.
 
-The benchmark also evaluates each portfolio on the shared simulated draws:
+The objective benchmark is designed to answer a stricter question: **does a mathematically targeted objective actually improve on the existing coverage generator, or does the existing generator already reach the same useful structure?**
 
-- **any-prize rate** — at least one ticket matches at least three main numbers;
-- **Division 4 or better rate** — at least one ticket matches at least four main numbers;
-- mean best main-number match per draw.
+## Common random numbers
 
-Under the current six-division Saturday Lotto structure, any ticket with at least three main numbers wins a prize, so supplementary numbers do not change the binary any-prize threshold. They still determine the exact division within some match categories.
+Every portfolio in one benchmark run is evaluated on the same simulated draw sample.
+
+This reduces irrelevant Monte Carlo noise caused by different strategies seeing different random outcomes. Portfolio-seed variation remains, which is the intended comparison dimension.
 
 ## Distribution summaries
 
-For coverage and QuickPick separately, each metric reports:
+Each benchmark metric can report:
 
 - mean;
 - population standard deviation;
@@ -86,41 +190,32 @@ For coverage and QuickPick separately, each metric reports:
 
 ## Probability of superiority
 
-For a metric, probability-of-superiority is the fraction of all coverage-vs-random portfolio pairs where the coverage portfolio scores better, with ties counted as one half.
-
-Examples:
-
-- `0.50` — no distribution-level ordering;
-- `0.75` — a randomly selected coverage portfolio beats a randomly selected QuickPick portfolio about three quarters of the time on that metric;
-- `1.00` — every sampled coverage portfolio beats every sampled QuickPick portfolio on that metric.
+Probability-of-superiority is the fraction of all strategy-vs-baseline portfolio pairs where the named strategy scores better on the named metric, with ties counted as one half.
 
 This is **not** the probability that a strategy wins the lottery.
 
 ## Bootstrap interval
 
-The benchmark resamples the coverage and QuickPick portfolio distributions independently and calculates the favourable mean difference for every resample.
+The benchmark independently resamples the compared portfolio distributions and calculates the favourable mean difference.
 
-The reported 95% interval is the 2.5th–97.5th percentile range of those bootstrap differences.
+The 95% interval is the 2.5th–97.5th percentile range of those bootstrap differences.
 
-Important limitation: this interval primarily describes **portfolio-seed variability conditional on the shared simulated draw sample**. A future enhancement can use nested resampling to include draw-sample uncertainty explicitly.
+Current limitation: this interval primarily describes **portfolio-seed variability conditional on the shared simulated draw sample**. Nested draw+portfolio resampling remains roadmap work.
 
-## Browser benchmark
+## Browser benchmark and certificates
 
-`benchmark.html` provides a smaller local benchmark that runs entirely in the browser.
+`benchmark.html` provides two evidence layers:
 
-It is intentionally labelled exploratory:
+- the existing smaller local exploratory multi-seed benchmark;
+- a Certified Probability panel populated from the generated reference coverage-set metrics.
 
-- fewer portfolio seeds;
-- fewer simulated draws;
-- no backend bootstrap interval;
-- useful for changing ticket counts interactively, not for release-level claims.
-
-The precomputed repository benchmark remains the reproducible reference.
+The certificate panel labels exact bounds separately from simulated estimates. If the current static statistics asset predates v2.1.2, the panel explicitly reports that a refreshed asset is pending rather than inventing values.
 
 ## Claim rules
 
-A release may say the coverage algorithm improves a structural metric only when the multi-seed distribution supports that statement.
-
-A release should not claim a lower-division outcome advantage merely because the point estimate is positive. The effect size, bootstrap interval, probability-of-superiority, sample sizes and benchmark seed must remain visible.
-
-No result from this benchmark changes Division 1 probability for equal-size distinct portfolios.
+- Never say a bound is exact unless the conditions for exactness have been proved.
+- Never infer a Division 1 advantage from lower-order portfolio structure.
+- Never report simulated training performance as evidence for a generator.
+- Never call probability-of-superiority the probability of winning.
+- Prefer exact certificates over Monte Carlo when the exact theorem applies.
+- If a targeted objective does not outperform the existing coverage generator out of sample, keep the simpler existing generator as the default.

--- a/docs/METHODOLOGY.md
+++ b/docs/METHODOLOGY.md
@@ -50,17 +50,88 @@ P(m,s) = C(6,m) × C(2,s) × C(37, 6-m-s) / C(45,6)
 
 The Division 1–6 probabilities are sums of the appropriate mutually exclusive categories.
 
-## Historical number diagnostics
+Under the current Saturday Lotto prize structure, **winning any prize is equivalent to matching at least three winning main numbers**. Supplementary matches decide which division applies within some categories, but do not change the binary any-prize event.
 
-Each number has marginal probability `6/45` of appearing among the six winning balls in a draw. Across `D` draws, its count has expected value:
+Likewise, **Division 4 or better is equivalent to matching at least four winning main numbers**.
+
+## Exact two-ticket event intersections
+
+For two six-number tickets sharing `r` numbers, partition the 45 balls into:
+
+- `r` shared numbers;
+- `6-r` numbers found only in ticket A;
+- `6-r` numbers found only in ticket B;
+- `33+r` numbers in neither ticket.
+
+For a threshold `k`, sum all ways to choose six winning main numbers such that both tickets receive at least `k` matches.
+
+If `x` shared, `y` A-only, `z` B-only and `w` neither numbers are selected, each valid term contributes:
 
 ```text
-E[X] = D × 6/45
+C(r,x) × C(6-r,y) × C(6-r,z) × C(33+r,w)
 ```
 
-The per-number z-score uses the binomial marginal variance. Entropy, χ² and pair counts are retained as exploratory diagnostics. They do not feed ticket generation.
+subject to:
 
-The project deliberately avoids attaching a naive χ² p-value to the 45 count cells because counts inside each draw are dependent. Formal global testing is reserved for Monte-Carlo-calibrated roadmap work.
+```text
+x + y >= k
+x + z >= k
+x + y + z + w = 6
+```
+
+The exact pair-event probability is the resulting count divided by `C(45,6)`.
+
+This calculation is used by the certified portfolio objectives and does not depend on historical draw data or Monte Carlo sampling.
+
+## Bonferroni portfolio lower bound
+
+Let `Ai` be the event that portfolio ticket `i` reaches a chosen main-match threshold. Define:
+
+```text
+S1 = Σ P(Ai)
+S2 = Σ P(Ai ∩ Aj), i < j
+```
+
+The second-order Bonferroni inequality gives:
+
+```text
+P(A1 ∪ ... ∪ An) >= max(0, S1 - S2)
+```
+
+The software computes both terms exactly.
+
+For the any-prize event (`k=3`), this is a **rigorous lower bound**, not generally the exact portfolio probability because three-way and higher intersections can remain.
+
+The ordinary union bound gives:
+
+```text
+P(A1 ∪ ... ∪ An) <= min(1, S1)
+```
+
+When pairwise intersections are zero, the lower and upper bounds meet and the exact probability is known.
+
+## Exact Division-4-or-better optimality theorem
+
+Take two six-number games with at most one shared number. If both were to match at least four of the same six winning main numbers, at least:
+
+```text
+4 + 4 - 1 = 7
+```
+
+distinct winning numbers would be required. Only six winning main numbers exist.
+
+Therefore their `>=4 main` events cannot occur together.
+
+If **every pair** in a portfolio shares at most one number, all pairwise `>=4 main` intersections are zero. The portfolio probability is then exactly:
+
+```text
+P(at least one game reaches >=4 main)
+  = n × P(one game reaches >=4 main)
+```
+
+No union of `n` events with those same marginal probabilities can exceed their sum. Such a portfolio therefore reaches the **global maximum possible Division-4-or-better probability for that ticket count**.
+
+This is an exact certificate and takes precedence over Monte Carlo evidence when it applies.
 
 ## Combinatorial portfolio coverage
 
@@ -76,7 +147,7 @@ For a set of tickets, the software counts the distinct subsets actually represen
 unique covered subsets / total subset placements
 ```
 
-The v2.1 generator samples many candidate tickets for each portfolio position and uses this lexicographic objective:
+The generic coverage generator samples candidate tickets and uses this lexicographic objective:
 
 1. maximise previously unseen quadruples;
 2. maximise previously unseen triples;
@@ -86,13 +157,57 @@ The v2.1 generator samples many candidate tickets for each portfolio position an
 
 This objective reduces measurable redundancy. It does **not** increase any individual six-number combination's chance of being drawn.
 
+## Certified bound-driven objectives
+
+Two additional generators optimise exact pair-event mathematics rather than historical or simulated outcomes.
+
+### Any-prize bound
+
+Every candidate six-number game has the same single-ticket any-prize probability. Therefore, within a greedy step, increasing the second-order Bonferroni lower bound is equivalent to reducing the sum of exact pairwise `>=3 main` event intersections with already selected games.
+
+The generator uses that pair-event cost as its primary objective and structural coverage only as a tie-breaker.
+
+It optimises a **rigorous lower bound**, not the exact any-prize union.
+
+### Division-4 bound
+
+The Division-4-bound generator first minimises exact pairwise `>=4 main` intersections, then uses the any-prize pair cost and subset coverage as tie-breakers.
+
+If the resulting portfolio receives the pairwise-disjoint certificate, its Division-4-or-better probability is exact and globally optimal for the ticket count.
+
+If not, the software reports only the available lower bound and does not label the result globally optimal.
+
+## Why direct simulated-training optimisation is not shipped
+
+A prototype attempted to optimise any-prize union directly by selecting candidate games that covered the most simulated training draws.
+
+Held-out experiments showed a substantial training/validation gap. The optimiser learned sampling noise and did not improve on the existing coverage design when evaluated on independent draws.
+
+That prototype is deliberately excluded from the recommended generators.
+
+Future stochastic optimisation work must use separate training and validation samples, report the generalisation gap and outperform the structural baseline out of sample before being considered for release.
+
 ## Monte Carlo portfolio simulation
 
 Simulation samples eight distinct balls uniformly from 45, treats the first six as winning and the remaining two as supplementary, and evaluates the highest prize division achieved by the portfolio.
 
 Reported hit-rate uncertainty uses a Wilson 95% interval. Simulation compares portfolio correlation/coverage; it cannot establish a predictive number-selection edge.
 
-The reference coverage-vs-QuickPick result is reproducible but represents only one pair of seeded portfolios. The roadmap therefore keeps repeated-seed strategy-difference analysis open.
+## Multi-seed benchmark
+
+The repository benchmark compares **distributions** of independently seeded coverage and QuickPick portfolios on one shared simulated draw sample.
+
+It reports:
+
+- structural metric distributions;
+- lower-division outcome distributions;
+- random-baseline quantiles;
+- probability-of-superiority;
+- bootstrap intervals for favourable mean differences.
+
+The shared-draw design reduces irrelevant Monte Carlo noise between strategies. Current bootstrap intervals primarily represent portfolio-seed uncertainty conditional on that draw sample. Nested draw+portfolio uncertainty remains roadmap work.
+
+See [`BENCHMARKING.md`](BENCHMARKING.md) for the fixed reference design and the certified-objective benchmark.
 
 ## Walk-forward historical evaluation
 
@@ -105,13 +220,23 @@ For each evaluated historical draw:
 
 This is an out-of-sample test of portfolio structure, not a predictive backtest.
 
+## Historical number diagnostics
+
+Each number has marginal probability `6/45` of appearing among the six winning balls in a draw. Across `D` draws, its count has expected value:
+
+```text
+E[X] = D × 6/45
+```
+
+The per-number z-score uses the binomial marginal variance. Entropy, χ² and pair counts are retained as exploratory diagnostics. They do not feed ticket generation.
+
+The project deliberately avoids attaching a naive χ² p-value to the 45 count cells because counts inside each draw are dependent. Formal global testing is reserved for Monte-Carlo-calibrated roadmap work.
+
 ## Experimental anti-crowding research
 
 Lottery-player selections are not uniformly distributed in many observed datasets. Published work documents preferences for birthdays/smaller numbers, 7, sequences and aesthetically meaningful patterns. In pari-mutuel prize structures, a popular combination can have more co-winners if drawn.
 
 The anti-crowding mode therefore penalises several such features when ranking otherwise random candidate tickets. The score is **not an estimated Australian Saturday Lotto popularity probability**, and the mode must not be described as improving draw odds.
-
-Useful background includes research on number preferences in lotteries, work on the payout cost associated with number 7, and Australian operator reporting of repeated player-picked combinations.
 
 ## Data validation and provenance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "saturday-lotto-lab"
-version = "2.1.0"
+version = "2.1.2"
 description = "Exact Saturday Lotto probability, audited data and combinatorial ticket-portfolio tooling"
 requires-python = ">=3.11"
 dependencies = ["beautifulsoup4>=4.12,<5"]

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'saturday-lotto-lab-v2-1-1';
+const CACHE_NAME = 'saturday-lotto-lab-v2-1-2';
 const STATIC_ASSETS = [
   './',
   './index.html',
@@ -7,6 +7,7 @@ const STATIC_ASSETS = [
   './assets/app.js',
   './assets/benchmark.css',
   './assets/benchmark.js',
+  './assets/certificates.js',
   './assets/favicon.svg',
   './assets/site.webmanifest',
   './assets/lotto_stats.json',

--- a/src/lotto_lab/__init__.py
+++ b/src/lotto_lab/__init__.py
@@ -1,3 +1,3 @@
 """Saturday Lotto Lab probability and coverage toolkit."""
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/src/lotto_lab/benchmark.py
+++ b/src/lotto_lab/benchmark.py
@@ -174,6 +174,42 @@ def _comparison(
         "probabilityOfSuperiority": probability_of_superiority(
             coverage_values, random_values, direction=direction
         ),
+        "inferenceSuppressed": False,
+    }
+
+
+def _exact_equality_override(
+    left_rows: Sequence[MetricRow],
+    right_rows: Sequence[MetricRow],
+    *,
+    simulated_metric: str,
+    exact_metric: str,
+    certificate_metric: str,
+) -> dict | None:
+    """Suppress Monte Carlo inference when exact certificates prove equal probabilities."""
+    all_certified = all(
+        row[certificate_metric] == 1.0 for row in [*left_rows, *right_rows]
+    )
+    exact_values = [row[exact_metric] for row in [*left_rows, *right_rows]]
+    exact_equal = bool(exact_values) and max(exact_values) == min(exact_values)
+    if not (all_certified and exact_equal):
+        return None
+
+    descriptive_difference = fmean(row[simulated_metric] for row in left_rows) - fmean(
+        row[simulated_metric] for row in right_rows
+    )
+    return {
+        "direction": "higher",
+        "inferenceSuppressed": True,
+        "exactProbabilityDifference": 0.0,
+        "descriptiveSimulatedMeanDifference": descriptive_difference,
+        "bootstrapMeanDifferenceCi95": None,
+        "probabilityOfSuperiority": None,
+        "reason": (
+            "Both strategy distributions are exactly certified at the same Division-4-or-better "
+            "probability. Any difference in the shared finite Monte Carlo draw sample is sampling "
+            "noise, so bootstrap inference on that simulated difference is suppressed."
+        ),
     }
 
 
@@ -336,6 +372,18 @@ def benchmark_probability_objectives(
             seed=seed + offset,
         )
 
+    division4_simulated_comparison = _exact_equality_override(
+        rows["division4Bound"],
+        rows["coverage"],
+        simulated_metric="division4OrBetterRate",
+        exact_metric="division4CertifiedProbability",
+        certificate_metric="division4GloballyOptimal",
+    )
+    if division4_simulated_comparison is None:
+        division4_simulated_comparison = compare(
+            "division4Bound", "coverage", "division4OrBetterRate", "higher", 202
+        )
+
     comparisons = {
         "anyPrizeBoundVsCoverage": {
             "anyPrizeBonferroniLowerBound": compare(
@@ -349,9 +397,7 @@ def benchmark_probability_objectives(
             "division4CertifiedProbability": compare(
                 "division4Bound", "coverage", "division4CertifiedProbability", "higher", 201
             ),
-            "division4OrBetterRate": compare(
-                "division4Bound", "coverage", "division4OrBetterRate", "higher", 202
-            ),
+            "division4OrBetterRate": division4_simulated_comparison,
         },
         "coverageVsRandom": {
             "anyPrizeRate": compare("coverage", "random", "anyPrizeRate", "higher", 301),
@@ -373,9 +419,9 @@ def benchmark_probability_objectives(
         "comparisons": comparisons,
         "note": (
             "The bound-driven generators optimise exact pairwise-event mathematics, not simulated "
-            "training outcomes. Monte Carlo draws are used only for out-of-sample comparison. A "
-            "Division-4+ global-optimality rate of 100% means every tested portfolio achieved "
-            "pairwise-disjoint >=4-main events, so no same-sized portfolio can have a higher "
-            "Division-4-or-better union probability."
+            "training outcomes. Monte Carlo draws are used only for out-of-sample comparison. When "
+            "exact certificates prove two strategy distributions have the same true probability, "
+            "Monte Carlo difference inference is suppressed rather than allowed to contradict the "
+            "known combinatorial result."
         ),
     }

--- a/src/lotto_lab/benchmark.py
+++ b/src/lotto_lab/benchmark.py
@@ -5,7 +5,14 @@ from collections.abc import Sequence
 from statistics import fmean, pstdev
 
 from .domain import BALL_COUNT, MAIN_COUNT
-from .tickets import Ticket, generate_coverage_tickets, generate_random_tickets, ticket_metrics
+from .tickets import (
+    Ticket,
+    generate_any_prize_bound_tickets,
+    generate_coverage_tickets,
+    generate_division4_bound_tickets,
+    generate_random_tickets,
+    ticket_metrics,
+)
 
 MetricRow = dict[str, float]
 
@@ -121,12 +128,21 @@ def _outcome_rates(tickets: Sequence[Ticket], draws: Sequence[frozenset[int]]) -
 def _portfolio_row(tickets: Sequence[Ticket], draws: Sequence[frozenset[int]]) -> MetricRow:
     metrics = ticket_metrics(tickets)
     outcomes = _outcome_rates(tickets, draws)
+    certificates = metrics["probabilityCertificates"]
+    any_prize = certificates["anyPrize"]
+    division4 = certificates["division4OrBetter"]
+    division4_certified = division4["exactProbability"]
+    if division4_certified is None:
+        division4_certified = division4["bonferroniLowerBound"]
     return {
         "pairCoverageEfficiency": float(metrics["pairCoverage"]["efficiency"]),
         "tripleCoverageEfficiency": float(metrics["tripleCoverage"]["efficiency"]),
         "quadCoverageEfficiency": float(metrics["quadrupleCoverage"]["efficiency"]),
         "maxPairwiseOverlap": float(metrics["maxPairwiseOverlap"]),
         "uniqueNumbers": float(metrics["uniqueNumbers"]),
+        "anyPrizeBonferroniLowerBound": float(any_prize["bonferroniLowerBound"]),
+        "division4CertifiedProbability": float(division4_certified),
+        "division4GloballyOptimal": float(bool(division4["globallyOptimalForTicketCount"])),
         **outcomes,
     }
 
@@ -211,6 +227,9 @@ def benchmark_portfolio_distributions(
         "quadCoverageEfficiency": "higher",
         "maxPairwiseOverlap": "lower",
         "uniqueNumbers": "higher",
+        "anyPrizeBonferroniLowerBound": "higher",
+        "division4CertifiedProbability": "higher",
+        "division4GloballyOptimal": "higher",
         "anyPrizeRate": "higher",
         "division4OrBetterRate": "higher",
         "meanBestMainMatch": "higher",
@@ -246,5 +265,117 @@ def benchmark_portfolio_distributions(
             "Coverage and QuickPick distributions use the same number of distinct standard games. "
             "Division 1 probability is therefore identical. Positive lower-division differences "
             "measure portfolio diversification, not prediction of future draw numbers."
+        ),
+    }
+
+
+def benchmark_probability_objectives(
+    ticket_count: int = 10,
+    *,
+    portfolios_per_objective: int = 24,
+    random_portfolios: int = 96,
+    trials: int = 5000,
+    seed: int = 20260822,
+    candidates_per_ticket: int = 320,
+    bootstrap_resamples: int = 2000,
+) -> dict:
+    """Compare subset, any-prize-bound and Division-4-bound objectives out of sample."""
+    if portfolios_per_objective < 2 or random_portfolios < 2:
+        raise ValueError("at least two portfolios are required in each distribution")
+    draws = _sample_main_draws(trials, seed=seed ^ 0x0B1E_C71E)
+
+    generators = {
+        "coverage": generate_coverage_tickets,
+        "anyPrizeBound": generate_any_prize_bound_tickets,
+        "division4Bound": generate_division4_bound_tickets,
+    }
+    rows: dict[str, list[MetricRow]] = {}
+    for strategy, generator in generators.items():
+        rows[strategy] = [
+            _portfolio_row(
+                generator(
+                    ticket_count,
+                    seed=f"objective:{seed}:{strategy}:{index}",
+                    candidates_per_ticket=candidates_per_ticket,
+                ),
+                draws,
+            )
+            for index in range(portfolios_per_objective)
+        ]
+    rows["random"] = [
+        _portfolio_row(
+            generate_random_tickets(ticket_count, seed=f"objective:{seed}:random:{index}"),
+            draws,
+        )
+        for index in range(random_portfolios)
+    ]
+
+    reported_metrics = (
+        "anyPrizeBonferroniLowerBound",
+        "anyPrizeRate",
+        "division4CertifiedProbability",
+        "division4OrBetterRate",
+        "division4GloballyOptimal",
+        "tripleCoverageEfficiency",
+        "maxPairwiseOverlap",
+    )
+    summaries = {
+        strategy: {
+            metric: distribution_summary([row[metric] for row in strategy_rows])
+            for metric in reported_metrics
+        }
+        for strategy, strategy_rows in rows.items()
+    }
+
+    def compare(left: str, right: str, metric: str, direction: str, offset: int) -> dict:
+        return _comparison(
+            [row[metric] for row in rows[left]],
+            [row[metric] for row in rows[right]],
+            direction=direction,
+            resamples=bootstrap_resamples,
+            seed=seed + offset,
+        )
+
+    comparisons = {
+        "anyPrizeBoundVsCoverage": {
+            "anyPrizeBonferroniLowerBound": compare(
+                "anyPrizeBound", "coverage", "anyPrizeBonferroniLowerBound", "higher", 101
+            ),
+            "anyPrizeRate": compare(
+                "anyPrizeBound", "coverage", "anyPrizeRate", "higher", 102
+            ),
+        },
+        "division4BoundVsCoverage": {
+            "division4CertifiedProbability": compare(
+                "division4Bound", "coverage", "division4CertifiedProbability", "higher", 201
+            ),
+            "division4OrBetterRate": compare(
+                "division4Bound", "coverage", "division4OrBetterRate", "higher", 202
+            ),
+        },
+        "coverageVsRandom": {
+            "anyPrizeRate": compare("coverage", "random", "anyPrizeRate", "higher", 301),
+            "division4OrBetterRate": compare(
+                "coverage", "random", "division4OrBetterRate", "higher", 302
+            ),
+        },
+    }
+
+    return {
+        "ticketCount": ticket_count,
+        "portfoliosPerObjective": portfolios_per_objective,
+        "randomPortfolios": random_portfolios,
+        "simulatedDraws": trials,
+        "seed": seed,
+        "candidatesPerTicket": candidates_per_ticket,
+        "divisionOneProbabilityEqual": True,
+        "strategies": summaries,
+        "comparisons": comparisons,
+        "note": (
+            "The bound-driven generators optimise exact pairwise-event mathematics, not simulated "
+            "training outcomes. Monte Carlo draws are used only for out-of-sample comparison. A "
+            "Division-4+ global-optimality rate of 100% means every tested portfolio achieved "
+            "pairwise-disjoint >=4-main events, so no same-sized portfolio can have a higher "
+            "Division-4-or-better union probability."
         ),
     }

--- a/src/lotto_lab/cli.py
+++ b/src/lotto_lab/cli.py
@@ -6,13 +6,19 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 
 from .analysis import build_statistics
-from .benchmark import benchmark_portfolio_distributions
+from .benchmark import benchmark_portfolio_distributions, benchmark_probability_objectives
 from .crowding import generate_anti_crowding_tickets
 from .data import load_draws, write_draws
 from .provenance import build_provenance, write_provenance
 from .scrape import refresh_dataset
 from .simulation import compare_strategies, walk_forward_backtest
-from .tickets import generate_coverage_tickets, generate_random_tickets, ticket_metrics
+from .tickets import (
+    generate_any_prize_bound_tickets,
+    generate_coverage_tickets,
+    generate_division4_bound_tickets,
+    generate_random_tickets,
+    ticket_metrics,
+)
 from .verify import fetch_secondary_html, parse_secondary_results, verify_latest_draws
 
 SECONDARY_REPORT = Path("assets/secondary_verification.json")
@@ -67,7 +73,17 @@ def build_parser() -> argparse.ArgumentParser:
 
     tickets = sub.add_parser("tickets", help="Generate distinct entries")
     tickets.add_argument("--count", type=int, default=10)
-    tickets.add_argument("--mode", choices=("coverage", "random", "anti-crowding"), default="coverage")
+    tickets.add_argument(
+        "--mode",
+        choices=(
+            "coverage",
+            "any-prize-bound",
+            "division4-bound",
+            "random",
+            "anti-crowding",
+        ),
+        default="coverage",
+    )
     tickets.add_argument("--seed")
     tickets.add_argument("--json", action="store_true")
 
@@ -87,6 +103,18 @@ def build_parser() -> argparse.ArgumentParser:
     benchmark.add_argument("--seed", type=int, default=20260822)
     benchmark.add_argument("--candidates-per-ticket", type=int, default=120)
     benchmark.add_argument("--bootstrap-resamples", type=int, default=2000)
+
+    objectives = sub.add_parser(
+        "benchmark-objectives",
+        help="Compare subset coverage with certified any-prize and Division-4 bound objectives",
+    )
+    objectives.add_argument("--count", type=int, default=10)
+    objectives.add_argument("--portfolios", type=int, default=24)
+    objectives.add_argument("--random-portfolios", type=int, default=96)
+    objectives.add_argument("--trials", type=int, default=5000)
+    objectives.add_argument("--seed", type=int, default=20260822)
+    objectives.add_argument("--candidates-per-ticket", type=int, default=320)
+    objectives.add_argument("--bootstrap-resamples", type=int, default=2000)
 
     backtest = sub.add_parser("backtest", help="Leakage-free historical portfolio-structure comparison")
     backtest.add_argument("--count", type=int, default=10)
@@ -127,25 +155,39 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "tickets":
         generators = {
             "coverage": generate_coverage_tickets,
+            "any-prize-bound": generate_any_prize_bound_tickets,
+            "division4-bound": generate_division4_bound_tickets,
             "random": generate_random_tickets,
             "anti-crowding": generate_anti_crowding_tickets,
         }
-        tickets = generators[args.mode](args.count, seed=args.seed)
+        generated = generators[args.mode](args.count, seed=args.seed)
         payload = {
             "mode": args.mode,
-            "tickets": [list(ticket) for ticket in tickets],
-            "metrics": ticket_metrics(tickets),
+            "tickets": [list(ticket) for ticket in generated],
+            "metrics": ticket_metrics(generated),
         }
         if args.json:
             print(json.dumps(payload, indent=2))
         else:
-            for index, ticket in enumerate(tickets, start=1):
+            for index, ticket in enumerate(generated, start=1):
                 print(f"{index:>2}: " + " ".join(f"{number:02d}" for number in ticket))
             metrics = payload["metrics"]
+            certificates = metrics["probabilityCertificates"]
+            any_prize = certificates["anyPrize"]
+            division4 = certificates["division4OrBetter"]
+            division4_status = (
+                "exact/global optimum"
+                if division4["globallyOptimalForTicketCount"]
+                else "lower bound only"
+            )
             print(
                 f"unique numbers {metrics['uniqueNumbers']}; max overlap {metrics['maxPairwiseOverlap']}; "
                 f"triple efficiency {metrics['tripleCoverage']['efficiency']:.1%}; "
                 f"Div 1 chance {metrics['divisionOneProbability']:.10%}"
+            )
+            print(
+                f"any-prize certified lower bound {any_prize['bonferroniLowerBound']:.6%}; "
+                f"Div 4+ {division4_status}"
             )
         return 0
 
@@ -157,6 +199,19 @@ def main(argv: list[str] | None = None) -> int:
         result = benchmark_portfolio_distributions(
             args.count,
             coverage_portfolios=args.coverage_portfolios,
+            random_portfolios=args.random_portfolios,
+            trials=args.trials,
+            seed=args.seed,
+            candidates_per_ticket=args.candidates_per_ticket,
+            bootstrap_resamples=args.bootstrap_resamples,
+        )
+        print(json.dumps(result, indent=2))
+        return 0
+
+    if args.command == "benchmark-objectives":
+        result = benchmark_probability_objectives(
+            args.count,
+            portfolios_per_objective=args.portfolios,
             random_portfolios=args.random_portfolios,
             trials=args.trials,
             seed=args.seed,

--- a/src/lotto_lab/portfolio.py
+++ b/src/lotto_lab/portfolio.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from functools import lru_cache
+from itertools import combinations
+from math import comb
+
+from .domain import BALL_COUNT, MAIN_COUNT
+from .probability import at_least_main_match_probability, combination_count
+
+
+@lru_cache(maxsize=None)
+def pair_event_intersection_count(overlap: int, threshold: int) -> int:
+    """Count winning main-number sets satisfying a match threshold for two tickets.
+
+    Two six-number tickets with `overlap` shared numbers partition the 45 balls into
+    shared, left-only, right-only and neither groups. Summing selections from those
+    four groups gives the exact number of six-main-number draws in which both tickets
+    match at least `threshold` main numbers.
+    """
+    if overlap < 0 or overlap > MAIN_COUNT:
+        raise ValueError("overlap must be between 0 and 6")
+    if threshold < 1 or threshold > MAIN_COUNT:
+        raise ValueError("threshold must be between 1 and 6")
+
+    shared = overlap
+    left_only = MAIN_COUNT - overlap
+    right_only = MAIN_COUNT - overlap
+    neither = BALL_COUNT - (2 * MAIN_COUNT - overlap)
+    favourable = 0
+
+    for shared_selected in range(shared + 1):
+        for left_selected in range(left_only + 1):
+            for right_selected in range(right_only + 1):
+                neither_selected = MAIN_COUNT - shared_selected - left_selected - right_selected
+                if neither_selected < 0 or neither_selected > neither:
+                    continue
+                if shared_selected + left_selected < threshold:
+                    continue
+                if shared_selected + right_selected < threshold:
+                    continue
+                favourable += (
+                    comb(shared, shared_selected)
+                    * comb(left_only, left_selected)
+                    * comb(right_only, right_selected)
+                    * comb(neither, neither_selected)
+                )
+    return favourable
+
+
+def pair_event_intersection_probability(overlap: int, threshold: int) -> float:
+    return pair_event_intersection_count(overlap, threshold) / combination_count()
+
+
+def portfolio_probability_certificate(
+    tickets: Sequence[Sequence[int]],
+    *,
+    threshold: int,
+) -> dict[str, float | int | bool | None]:
+    """Return rigorous union bounds and an exact certificate when events are disjoint.
+
+    The event is: at least one portfolio ticket matches `threshold` or more of the six
+    winning main numbers. For threshold=3 this is equivalent to winning any Saturday
+    Lotto prize division. For threshold=4 it is equivalent to Division 4 or better.
+
+    Bonferroni gives P(union) >= S1 - S2 using exact single-ticket and pairwise event
+    probabilities. The ordinary union bound gives P(union) <= S1. If every pairwise
+    intersection is zero, both bounds meet, so the exact portfolio probability is S1
+    and no same-sized portfolio can do better.
+    """
+    if threshold < 1 or threshold > MAIN_COUNT:
+        raise ValueError("threshold must be between 1 and 6")
+
+    normalized = [tuple(ticket) for ticket in tickets]
+    for ticket in normalized:
+        if len(ticket) != MAIN_COUNT or len(set(ticket)) != MAIN_COUNT:
+            raise ValueError("every ticket must contain six distinct numbers")
+        if any(number < 1 or number > BALL_COUNT for number in ticket):
+            raise ValueError("ticket numbers must be between 1 and 45")
+
+    single_probability = at_least_main_match_probability(threshold)
+    first_order_sum = len(normalized) * single_probability
+    second_order_sum = 0.0
+    pairwise_disjoint = True
+    maximum_overlap = 0
+
+    for left, right in combinations(normalized, 2):
+        overlap = len(set(left) & set(right))
+        maximum_overlap = max(maximum_overlap, overlap)
+        intersection = pair_event_intersection_probability(overlap, threshold)
+        second_order_sum += intersection
+        if intersection > 0:
+            pairwise_disjoint = False
+
+    lower_bound = max(0.0, first_order_sum - second_order_sum)
+    upper_bound = min(1.0, first_order_sum)
+    exact_probability = first_order_sum if pairwise_disjoint else None
+
+    return {
+        "threshold": threshold,
+        "ticketCount": len(normalized),
+        "singleTicketProbability": single_probability,
+        "firstOrderUnionBound": upper_bound,
+        "pairIntersectionProbabilitySum": second_order_sum,
+        "bonferroniLowerBound": lower_bound,
+        "pairwiseDisjointEvents": pairwise_disjoint,
+        "maximumTicketOverlap": maximum_overlap,
+        "exactProbability": exact_probability,
+        "globallyOptimalForTicketCount": pairwise_disjoint,
+    }

--- a/src/lotto_lab/portfolio.py
+++ b/src/lotto_lab/portfolio.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from functools import lru_cache
+from functools import cache
 from itertools import combinations
 from math import comb
 
@@ -9,7 +9,7 @@ from .domain import BALL_COUNT, MAIN_COUNT
 from .probability import at_least_main_match_probability, combination_count
 
 
-@lru_cache(maxsize=None)
+@cache
 def pair_event_intersection_count(overlap: int, threshold: int) -> int:
     """Count winning main-number sets satisfying a match threshold for two tickets.
 

--- a/src/lotto_lab/tickets.py
+++ b/src/lotto_lab/tickets.py
@@ -8,6 +8,7 @@ from itertools import combinations
 from math import comb
 
 from .domain import BALL_COUNT, MAIN_COUNT
+from .portfolio import pair_event_intersection_count, portfolio_probability_certificate
 from .probability import division_one_probability
 
 Ticket = tuple[int, ...]
@@ -63,6 +64,22 @@ def subset_coverage(tickets: Iterable[Ticket], subset_size: int) -> dict[str, fl
     }
 
 
+def _candidate_structure(
+    candidate: Ticket,
+    tickets: list[Ticket],
+    usage: Counter[int],
+    covered: dict[int, set[tuple[int, ...]]],
+) -> tuple[int, int, int, int, int, list[int]]:
+    new4 = sum(1 for subset in combinations(candidate, 4) if subset not in covered[4])
+    new3 = sum(1 for subset in combinations(candidate, 3) if subset not in covered[3])
+    new2 = sum(1 for subset in combinations(candidate, 2) if subset not in covered[2])
+    candidate_set = set(candidate)
+    overlaps = [len(candidate_set & set(ticket)) for ticket in tickets]
+    max_overlap = max(overlaps, default=0)
+    usage_cost = sum(usage[number] for number in candidate)
+    return new4, new3, new2, max_overlap, usage_cost, overlaps
+
+
 def generate_coverage_tickets(
     count: int,
     seed: str | int | None = None,
@@ -82,7 +99,7 @@ def generate_coverage_tickets(
     tickets: list[Ticket] = []
     seen: set[Ticket] = set()
     usage = Counter({number: 0 for number in range(1, BALL_COUNT + 1)})
-    covered = {2: set(), 3: set(), 4: set()}
+    covered: dict[int, set[tuple[int, ...]]] = {2: set(), 3: set(), 4: set()}
 
     for _ in range(count):
         best_ticket: Ticket | None = None
@@ -91,11 +108,9 @@ def generate_coverage_tickets(
             candidate = _random_ticket(rng)
             if candidate in seen:
                 continue
-            new4 = sum(1 for s in combinations(candidate, 4) if s not in covered[4])
-            new3 = sum(1 for s in combinations(candidate, 3) if s not in covered[3])
-            new2 = sum(1 for s in combinations(candidate, 2) if s not in covered[2])
-            max_overlap = max((len(set(candidate) & set(ticket)) for ticket in tickets), default=0)
-            usage_cost = sum(usage[number] for number in candidate)
+            new4, new3, new2, max_overlap, usage_cost, _overlaps = _candidate_structure(
+                candidate, tickets, usage, covered
+            )
             score = (new4, new3, new2, -max_overlap, -usage_cost, rng.random())
             if best_score is None or score > best_score:
                 best_score = score
@@ -112,6 +127,106 @@ def generate_coverage_tickets(
     return tickets
 
 
+def generate_probability_bound_tickets(
+    count: int,
+    seed: str | int | None = None,
+    *,
+    event_threshold: int,
+    candidates_per_ticket: int = 320,
+) -> list[Ticket]:
+    """Greedily optimise an exact second-order union-probability lower bound.
+
+    Every candidate ticket has the same single-ticket event probability. Maximising
+    the Bonferroni lower bound therefore means minimising the exact sum of its pairwise
+    event intersections with tickets already selected. Structural coverage then acts
+    only as a tie-breaker.
+
+    threshold=3 targets the rigorous lower bound for winning any prize.
+    threshold=4 targets Division 4-or-better and can achieve an exact global optimum
+    whenever all >=4-main ticket events become pairwise disjoint.
+    """
+    _validate_count(count)
+    if event_threshold < 3 or event_threshold > MAIN_COUNT:
+        raise ValueError("event_threshold must be between 3 and 6")
+    if candidates_per_ticket < 20:
+        raise ValueError("candidates_per_ticket must be at least 20")
+
+    rng = _rng(seed)
+    tickets: list[Ticket] = []
+    seen: set[Ticket] = set()
+    usage = Counter({number: 0 for number in range(1, BALL_COUNT + 1)})
+    covered: dict[int, set[tuple[int, ...]]] = {2: set(), 3: set(), 4: set()}
+
+    for _ in range(count):
+        best_ticket: Ticket | None = None
+        best_score: tuple[float, ...] | None = None
+        for _candidate in range(candidates_per_ticket):
+            candidate = _random_ticket(rng)
+            if candidate in seen:
+                continue
+            new4, new3, new2, max_overlap, usage_cost, overlaps = _candidate_structure(
+                candidate, tickets, usage, covered
+            )
+            target_pair_cost = sum(
+                pair_event_intersection_count(overlap, event_threshold)
+                for overlap in overlaps
+            )
+            any_prize_pair_cost = sum(
+                pair_event_intersection_count(overlap, 3) for overlap in overlaps
+            )
+            score = (
+                -target_pair_cost,
+                -any_prize_pair_cost,
+                new4,
+                new3,
+                new2,
+                -max_overlap,
+                -usage_cost,
+                rng.random(),
+            )
+            if best_score is None or score > best_score:
+                best_score = score
+                best_ticket = candidate
+
+        if best_ticket is None:
+            raise RuntimeError("unable to generate a unique probability-bound ticket")
+        tickets.append(best_ticket)
+        seen.add(best_ticket)
+        usage.update(best_ticket)
+        for size in covered:
+            covered[size].update(combinations(best_ticket, size))
+
+    return tickets
+
+
+def generate_any_prize_bound_tickets(
+    count: int,
+    seed: str | int | None = None,
+    *,
+    candidates_per_ticket: int = 320,
+) -> list[Ticket]:
+    return generate_probability_bound_tickets(
+        count,
+        seed,
+        event_threshold=3,
+        candidates_per_ticket=candidates_per_ticket,
+    )
+
+
+def generate_division4_bound_tickets(
+    count: int,
+    seed: str | int | None = None,
+    *,
+    candidates_per_ticket: int = 320,
+) -> list[Ticket]:
+    return generate_probability_bound_tickets(
+        count,
+        seed,
+        event_threshold=4,
+        candidates_per_ticket=candidates_per_ticket,
+    )
+
+
 def ticket_metrics(tickets: Iterable[Ticket]) -> dict[str, float | int | dict]:
     ticket_list = list(tickets)
     if not ticket_list:
@@ -125,6 +240,10 @@ def ticket_metrics(tickets: Iterable[Ticket]) -> dict[str, float | int | dict]:
             "pairCoverage": subset_coverage([], 2),
             "tripleCoverage": subset_coverage([], 3),
             "quadrupleCoverage": subset_coverage([], 4),
+            "probabilityCertificates": {
+                "anyPrize": portfolio_probability_certificate([], threshold=3),
+                "division4OrBetter": portfolio_probability_certificate([], threshold=4),
+            },
         }
 
     usage = Counter(number for ticket in ticket_list for number in ticket)
@@ -140,6 +259,10 @@ def ticket_metrics(tickets: Iterable[Ticket]) -> dict[str, float | int | dict]:
         "pairCoverage": subset_coverage(ticket_list, 2),
         "tripleCoverage": subset_coverage(ticket_list, 3),
         "quadrupleCoverage": subset_coverage(ticket_list, 4),
+        "probabilityCertificates": {
+            "anyPrize": portfolio_probability_certificate(ticket_list, threshold=3),
+            "division4OrBetter": portfolio_probability_certificate(ticket_list, threshold=4),
+        },
     }
 
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -17,6 +17,10 @@ class AnalysisTests(unittest.TestCase):
         self.assertEqual(stats["dataset"]["lastDraw"], "2026-01-10")
         self.assertEqual(stats["game"]["divisionOneCombinations"], 8_145_060)
         self.assertEqual(len(stats["probabilityModel"]["prizeDivisions"]), 6)
+        certificates = stats["referenceCoverageSet"]["metrics"]["probabilityCertificates"]
+        self.assertIn("anyPrize", certificates)
+        self.assertIn("division4OrBetter", certificates)
+        self.assertGreater(certificates["anyPrize"]["bonferroniLowerBound"], 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_benchmark_site.py
+++ b/tests/test_benchmark_site.py
@@ -8,19 +8,31 @@ class BenchmarkSiteTests(unittest.TestCase):
     def test_benchmark_page_assets_exist(self):
         html = (ROOT / "benchmark.html").read_text(encoding="utf-8")
         js = (ROOT / "assets/benchmark.js").read_text(encoding="utf-8")
+        certificate_js = (ROOT / "assets/certificates.js").read_text(encoding="utf-8")
         service_worker = (ROOT / "service-worker.js").read_text(encoding="utf-8")
-        for path in ("assets/benchmark.css", "assets/benchmark.js", "benchmark.html"):
+        for path in (
+            "assets/benchmark.css",
+            "assets/benchmark.js",
+            "assets/certificates.js",
+            "benchmark.html",
+        ):
             self.assertTrue((ROOT / path).exists(), path)
         self.assertIn("assets/benchmark.css", html)
         self.assertIn("assets/benchmark.js", html)
+        self.assertIn("assets/certificates.js", html)
         self.assertIn("referenceBenchmark", js)
+        self.assertIn("probabilityCertificates", certificate_js)
         self.assertIn("./benchmark.html", service_worker)
         self.assertIn("./assets/benchmark.js", service_worker)
+        self.assertIn("./assets/certificates.js", service_worker)
 
-    def test_benchmark_page_has_evidence_mount_point(self):
+    def test_benchmark_page_has_evidence_and_certificate_mount_points(self):
         html = (ROOT / "benchmark.html").read_text(encoding="utf-8")
         self.assertIn('id="evidence"', html)
-        self.assertIn("Multi-seed", html)
+        self.assertIn('id="certificates"', html)
+        self.assertIn('id="cert-any-lower"', html)
+        self.assertIn('id="cert-d4-exact"', html)
+        self.assertIn("Certified Probability", html)
 
 
 if __name__ == "__main__":

--- a/tests/test_objective_benchmark_v212.py
+++ b/tests/test_objective_benchmark_v212.py
@@ -1,6 +1,6 @@
 import unittest
 
-from lotto_lab.benchmark import benchmark_probability_objectives
+from lotto_lab.benchmark import _exact_equality_override, benchmark_probability_objectives
 
 
 class ObjectiveBenchmarkV212Tests(unittest.TestCase):
@@ -29,6 +29,45 @@ class ObjectiveBenchmarkV212Tests(unittest.TestCase):
         )
         self.assertIn("anyPrizeBoundVsCoverage", result["comparisons"])
         self.assertIn("division4BoundVsCoverage", result["comparisons"])
+
+    def test_exact_equality_suppresses_monte_carlo_inference(self):
+        left = [
+            {
+                "division4GloballyOptimal": 1.0,
+                "division4CertifiedProbability": 0.0139,
+                "division4OrBetterRate": 0.016,
+            },
+            {
+                "division4GloballyOptimal": 1.0,
+                "division4CertifiedProbability": 0.0139,
+                "division4OrBetterRate": 0.015,
+            },
+        ]
+        right = [
+            {
+                "division4GloballyOptimal": 1.0,
+                "division4CertifiedProbability": 0.0139,
+                "division4OrBetterRate": 0.012,
+            },
+            {
+                "division4GloballyOptimal": 1.0,
+                "division4CertifiedProbability": 0.0139,
+                "division4OrBetterRate": 0.013,
+            },
+        ]
+        comparison = _exact_equality_override(
+            left,
+            right,
+            simulated_metric="division4OrBetterRate",
+            exact_metric="division4CertifiedProbability",
+            certificate_metric="division4GloballyOptimal",
+        )
+        self.assertIsNotNone(comparison)
+        self.assertTrue(comparison["inferenceSuppressed"])
+        self.assertEqual(comparison["exactProbabilityDifference"], 0.0)
+        self.assertIsNone(comparison["bootstrapMeanDifferenceCi95"])
+        self.assertIsNone(comparison["probabilityOfSuperiority"])
+        self.assertNotEqual(comparison["descriptiveSimulatedMeanDifference"], 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_objective_benchmark_v212.py
+++ b/tests/test_objective_benchmark_v212.py
@@ -1,0 +1,35 @@
+import unittest
+
+from lotto_lab.benchmark import benchmark_probability_objectives
+
+
+class ObjectiveBenchmarkV212Tests(unittest.TestCase):
+    def test_objective_benchmark_keeps_division_one_equal_and_reports_certificates(self):
+        result = benchmark_probability_objectives(
+            6,
+            portfolios_per_objective=3,
+            random_portfolios=4,
+            trials=400,
+            seed=321,
+            candidates_per_ticket=40,
+            bootstrap_resamples=100,
+        )
+        self.assertTrue(result["divisionOneProbabilityEqual"])
+        self.assertIn("coverage", result["strategies"])
+        self.assertIn("anyPrizeBound", result["strategies"])
+        self.assertIn("division4Bound", result["strategies"])
+        self.assertIn("random", result["strategies"])
+        self.assertIn(
+            "anyPrizeBonferroniLowerBound",
+            result["strategies"]["anyPrizeBound"],
+        )
+        self.assertIn(
+            "division4GloballyOptimal",
+            result["strategies"]["division4Bound"],
+        )
+        self.assertIn("anyPrizeBoundVsCoverage", result["comparisons"])
+        self.assertIn("division4BoundVsCoverage", result["comparisons"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_portfolio_certificates_v212.py
+++ b/tests/test_portfolio_certificates_v212.py
@@ -1,0 +1,69 @@
+import unittest
+
+from lotto_lab.portfolio import (
+    pair_event_intersection_count,
+    portfolio_probability_certificate,
+)
+from lotto_lab.probability import at_least_main_match_probability
+from lotto_lab.tickets import (
+    generate_any_prize_bound_tickets,
+    generate_division4_bound_tickets,
+    ticket_metrics,
+)
+
+
+class PortfolioCertificateV212Tests(unittest.TestCase):
+    def test_pair_intersection_counts_match_exact_combinatorics(self):
+        self.assertEqual(pair_event_intersection_count(0, 3), 400)
+        self.assertEqual(pair_event_intersection_count(1, 3), 3700)
+        self.assertEqual(pair_event_intersection_count(0, 4), 0)
+        self.assertEqual(pair_event_intersection_count(1, 4), 0)
+        self.assertEqual(pair_event_intersection_count(2, 4), 36)
+
+    def test_overlap_one_makes_division4_events_pairwise_disjoint(self):
+        tickets = [
+            (1, 2, 3, 4, 5, 6),
+            (1, 7, 8, 9, 10, 11),
+        ]
+        certificate = portfolio_probability_certificate(tickets, threshold=4)
+        expected = 2 * at_least_main_match_probability(4)
+        self.assertTrue(certificate["pairwiseDisjointEvents"])
+        self.assertTrue(certificate["globallyOptimalForTicketCount"])
+        self.assertAlmostEqual(certificate["exactProbability"], expected)
+        self.assertAlmostEqual(certificate["bonferroniLowerBound"], expected)
+        self.assertAlmostEqual(certificate["firstOrderUnionBound"], expected)
+
+    def test_any_prize_certificate_is_a_bound_not_false_exactness(self):
+        tickets = [
+            (1, 2, 3, 4, 5, 6),
+            (7, 8, 9, 10, 11, 12),
+        ]
+        certificate = portfolio_probability_certificate(tickets, threshold=3)
+        self.assertFalse(certificate["pairwiseDisjointEvents"])
+        self.assertIsNone(certificate["exactProbability"])
+        self.assertLess(
+            certificate["bonferroniLowerBound"],
+            certificate["firstOrderUnionBound"],
+        )
+
+    def test_ticket_metrics_include_both_probability_certificates(self):
+        tickets = generate_any_prize_bound_tickets(5, seed="certificate-test")
+        certificates = ticket_metrics(tickets)["probabilityCertificates"]
+        self.assertIn("anyPrize", certificates)
+        self.assertIn("division4OrBetter", certificates)
+        self.assertGreater(certificates["anyPrize"]["bonferroniLowerBound"], 0)
+
+    def test_division4_bound_generator_can_produce_global_optimum_for_ten_games(self):
+        tickets = generate_division4_bound_tickets(
+            10,
+            seed="division4-certificate",
+            candidates_per_ticket=600,
+        )
+        certificate = ticket_metrics(tickets)["probabilityCertificates"]["division4OrBetter"]
+        self.assertLessEqual(ticket_metrics(tickets)["maxPairwiseOverlap"], 1)
+        self.assertTrue(certificate["globallyOptimalForTicketCount"])
+        self.assertIsNotNone(certificate["exactProbability"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## v2.1.2 — Certified portfolio probability objectives

Continues roadmap issue #17 with mathematically certified lower-division portfolio objectives rather than a sampled-training optimiser.

### Exact probability certificates
- exact two-ticket intersection counts/probabilities for any `>=k main` event
- exact second-order Bonferroni lower bound `S1 - S2` for portfolio union probability
- ordinary union upper bound `S1`
- exact probability + global-optimality certificate when pairwise event intersections are zero
- proof-backed result: if every pair of games shares at most one number, their `>=4 main` events are pairwise disjoint, so Division 4-or-better probability reaches the global maximum for that ticket count

For 10 games, that certified global optimum is **1.393482675%** for Division 4 or better.

### Ticket objectives
- `coverage`: existing generic quad/triple/pair diversity — **remains the recommended default**
- `any-prize-bound`: minimises exact pairwise `>=3 main` intersection cost and slightly tightens the rigorous Bonferroni lower bound
- `division4-bound`: minimises exact pairwise `>=4 main` intersections and provides an explicit route to the global-optimality certificate
- `random`: uniform QuickPick baseline
- both bound-driven modes expose certificates through `ticket_metrics`

### Fixed CI objective benchmark finding
10 games; 12 portfolios for each structured objective; 48 QuickPick portfolios; 4,000 shared held-out simulated draws; seed `20260822`; 320 candidates/game.

Mean results:
- Coverage: any-prize lower bound **22.9986%**; simulated any-prize **23.1062%**; Division-4 certificate rate **100%**
- Any-prize bound: lower bound **23.0054%**; simulated any-prize **22.9854%**; Division-4 certificate rate **100%**
- Division-4 bound: lower bound **23.0020%**; simulated any-prize **23.0375%**; Division-4 certificate rate **100%**
- QuickPick: lower bound **21.1771%**; simulated any-prize **21.3313%**; Division-4 certificate rate **0%** in this fixed sample

Any-prize-bound vs Coverage:
- rigorous lower-bound improvement: about **+0.0068 percentage points**; bootstrap interval **0 to +0.0169 points**
- held-out simulated any-prize difference: about **−0.1208 points**; bootstrap 95% interval **−0.7606 to +0.5126 points**; P(superiority) ≈ **45.1%**
- therefore **no demonstrated held-out any-prize advantage**, so Coverage remains the default

Coverage vs QuickPick any-prize:
- held-out difference about **+1.775 points**
- bootstrap 95% interval about **+1.290 to +2.233 points**
- P(superiority) ≈ **96.6%** in this fixed benchmark

Division-4-bound vs Coverage:
- both distributions are exactly certified at the same true probability
- exact probability difference: **0**
- Monte Carlo difference inference is now deliberately suppressed; a finite shared draw sample cannot overrule known exact equality

### Negative result preserved
A direct optimiser trained on sampled any-prize outcomes was prototyped and evaluated on independent draws. It overfit the training sample and failed to improve on the existing coverage design, so it is deliberately **not** shipped as a recommended mode.

### Web / docs
- Certified Probability panel in Benchmark Lab
- separates exact bounds/certificates from Monte Carlo evidence
- explicitly shows pending state until refreshed stats contain certificate fields
- updated methodology, benchmark specification, README, roadmap and changelog
- service-worker cache updated for certificate UI

### Validation
- Ruff: pass
- Python compile: pass
- **46/46 unit tests: pass**
- full stats/provenance regeneration across **2,053 tracked draws: pass**
- fixed certified-objective benchmark: pass
- browser JS/service-worker syntax: pass
- static-site references: pass
- changed-file audit: 19 intended source/UI/test/doc/workflow files; **no historical CSV changes**

### Guardrails
- Bonferroni lower bounds are never described as exact unless disjointness proves exactness
- exact mathematics overrides noisy simulation when the two conflict
- Division 1 remains identical for same-sized distinct portfolios
- no simulated-training performance is presented as evidence
- no historical number frequencies enter any bound-driven objective

Issue #17 remains open for higher-order/exact any-prize union optimisation, packing-range analysis, alternative optimiser benchmarking and nested draw+portfolio uncertainty.