### PR TITLE
v2.1.4: exact-guided local portfolio search

### DIFF
--- a/.github/workflows/data-refresh.yml
+++ b/.github/workflows/data-refresh.yml
@@ -50,11 +50,16 @@ jobs:
               try:
                   payload = json.loads(stats.read_text(encoding='utf-8'))
                   exact_reference = payload.get('referenceCoverageSet', {}).get('exactAnyPrize', {})
+                  local_reference = payload.get('referenceExactLocalSearch', {})
+                  local_final = local_reference.get('finalExactAnyPrize', {})
                   stats_current = (
                       payload.get('schemaVersion') == 3
                       and exact_reference.get('exact') is True
                       and exact_reference.get('totalWinningMainSets') == 8_145_060
                       and exact_reference.get('probability') is not None
+                      and local_final.get('exact') is True
+                      and local_reference.get('improvementWinningMainSets') is not None
+                      and local_reference.get('preservedDivision4Optimality') is True
                   )
               except (OSError, json.JSONDecodeError):
                   pass

--- a/.github/workflows/local-search-benchmark.yml
+++ b/.github/workflows/local-search-benchmark.yml
@@ -1,0 +1,81 @@
+name: Exact local-search benchmark
+
+on:
+  pull_request:
+    paths:
+      - 'src/lotto_lab/optimizer.py'
+      - 'src/lotto_lab/search_benchmark.py'
+      - 'src/lotto_lab/portfolio.py'
+      - 'src/lotto_lab/tickets.py'
+      - 'src/lotto_lab/cli.py'
+      - '.github/workflows/local-search-benchmark.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  paired-exact-search:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: Install dependencies
+        run: python -m pip install -r requirements-dev.txt
+      - name: Paired exact 10-game local-search benchmark
+        env:
+          PYTHONPATH: src
+        run: |
+          python -m lotto_lab benchmark-local-search \
+            --count 10 \
+            --portfolios 12 \
+            --seed 20260822 \
+            --candidates-per-ticket 320 \
+            --iterations 2 \
+            --exact-shortlist 4 \
+            --exploration-candidates 1 \
+            --bootstrap-resamples 1200 > /tmp/local-search.json
+          python -m json.tool /tmp/local-search.json >/dev/null
+          python - <<'PY'
+          import json
+
+          with open('/tmp/local-search.json', encoding='utf-8') as handle:
+              result = json.load(handle)
+
+          assert result['exact'] is True
+          assert result['pairedDesign'] is True
+          assert result['divisionOneProbabilityEqual'] is True
+          assert result['allExactImprovementsNonNegative'] is True
+          assert result['allExistingDivision4OptimaPreserved'] is True
+
+          summary = {
+              'baselineMean': result['baseline']['mean'],
+              'finalMean': result['final']['mean'],
+              'meanImprovementProbability': result['improvementProbability']['mean'],
+              'meanImprovementWinningMainSets': result['improvementWinningMainSets']['mean'],
+              'ci95': result['pairedMeanImprovementCi95'],
+              'improvedPortfolioFraction': result['improvedPortfolioFraction'],
+              'unchangedPortfolioFraction': result['unchangedPortfolioFraction'],
+          }
+          print('EXACT_LOCAL_SEARCH_SUMMARY=' + json.dumps(summary, sort_keys=True))
+          print(
+              'EXACT_LOCAL_SEARCH_ROWS=' + json.dumps(
+                  [
+                      {
+                          'index': row['index'],
+                          'improvementWinningMainSets': row['improvementWinningMainSets'],
+                          'acceptedMoves': row['acceptedMoves'],
+                          'exactEvaluations': row['exactEvaluations'],
+                          'screenedNeighbours': row['screenedNeighbours'],
+                          'd4Before': row['baselineDivision4Optimal'],
+                          'd4After': row['finalDivision4Optimal'],
+                      }
+                      for row in result['rows']
+                  ],
+                  sort_keys=True,
+              )
+          )
+          PY

--- a/.github/workflows/local-search-benchmark.yml
+++ b/.github/workflows/local-search-benchmark.yml
@@ -23,21 +23,20 @@ jobs:
         with:
           python-version: '3.12'
           cache: pip
-      - name: Install dependencies
-        run: python -m pip install -r requirements-dev.txt
-      - name: Paired exact 10-game local-search benchmark
+      - name: Paired exact 10-game local-search confirmation
         env:
           PYTHONPATH: src
         run: |
+          python -m pip install -r requirements-dev.txt
           python -m lotto_lab benchmark-local-search \
             --count 10 \
-            --portfolios 12 \
-            --seed 20260822 \
+            --portfolios 16 \
+            --seed 20260823 \
             --candidates-per-ticket 320 \
             --iterations 2 \
             --exact-shortlist 4 \
             --exploration-candidates 1 \
-            --bootstrap-resamples 1200 > /tmp/local-search.json
+            --bootstrap-resamples 1600 > /tmp/local-search.json
           python -m json.tool /tmp/local-search.json >/dev/null
           python - <<'PY'
           import json
@@ -50,6 +49,8 @@ jobs:
           assert result['divisionOneProbabilityEqual'] is True
           assert result['allExactImprovementsNonNegative'] is True
           assert result['allExistingDivision4OptimaPreserved'] is True
+          assert result['seed'] == 20260823
+          assert result['portfolioPairs'] == 16
 
           summary = {
               'baselineMean': result['baseline']['mean'],
@@ -60,7 +61,7 @@ jobs:
               'improvedPortfolioFraction': result['improvedPortfolioFraction'],
               'unchangedPortfolioFraction': result['unchangedPortfolioFraction'],
           }
-          print('EXACT_LOCAL_SEARCH_SUMMARY=' + json.dumps(summary, sort_keys=True))
+          print('EXACT_LOCAL_SEARCH_CONFIRMATION=' + json.dumps(summary, sort_keys=True))
           print(
               'EXACT_LOCAL_SEARCH_ROWS=' + json.dumps(
                   [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 2.1.4 — Exact-guided local portfolio search
+
+### Added
+
+- `exact-local` portfolio mode: start from Coverage, enumerate one-number swaps, screen with exact pair-intersection/Bonferroni structure, then accept only moves that increase the full exact any-prize winning-set count;
+- `lotto-lab optimize-any-prize` for an auditable before/after optimisation report;
+- paired exact local-search benchmark comparing each refined portfolio with the exact Coverage portfolio it started from;
+- explicit preservation of an existing Division-4-or-better global-optimality certificate;
+- move history with before/after ticket values and exact winning-set improvement;
+- generated `referenceExactLocalSearch` statistics and Benchmark Lab display;
+- dedicated holdout workflow using a different root seed from the development benchmark.
+
+### Holdout finding
+
+The release search budget was frozen at **2 passes / 4 bound-ranked exact candidates / 1 exploration candidate** before the independent confirmation run.
+
+On 16 new 10-game Coverage portfolios rooted at seed `20260823`:
+
+- **11/16 improved** and **5/16 were unchanged**;
+- no portfolio worsened because acceptance requires a strictly larger exact integer winning-set count;
+- mean improvement was **91.75 additional winning-main sets**;
+- mean exact any-prize improvement was about **+0.001126 percentage points**;
+- paired portfolio-seed bootstrap 95% interval was about **+0.000636 to +0.001664 points**;
+- every existing Division-4 global-optimality certificate was preserved;
+- Division 1 probability remained unchanged because the number of distinct standard games did not change.
+
+Coverage remains the fast balanced default. `exact-local` is an optional higher-compute refinement for practical smaller portfolios. It is guaranteed non-worse than its own Coverage starting point on the exact any-prize objective, but it is **not** a proof of global optimality.
+
+### Guardrails
+
+- no simulated draw outcomes train or score accepted mutations;
+- a cheap Bonferroni score only screens neighbours; the full exact DP decides acceptance;
+- development and confirmation seeds are separate;
+- the search cannot trade away an existing exact Division-4+ optimum by default;
+- local improvement is not described as a future-number prediction or Division 1 edge.
+
 ## 2.1.3 — Exact any-prize portfolio probability
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,6 +22,33 @@ Number selection cannot improve that Division 1 probability if the draw is fair.
 
 See [`docs/ODDS_OPTIMISATION.md`](docs/ODDS_OPTIMISATION.md), [`docs/BENCHMARKING.md`](docs/BENCHMARKING.md) and [`docs/EXACT_ANY_PRIZE.md`](docs/EXACT_ANY_PRIZE.md) for the claim hierarchy and limitations.
 
+## v2.1.4 highlights
+
+### Exact-guided local refinement
+
+`exact-local` starts from the fast Coverage portfolio and searches one-number swap neighbours. The cheap exact Bonferroni lower bound is used only to shortlist candidates; a mutation is accepted **only** when the full exact dynamic-programming evaluator proves that it increases the integer count of six-main-number draws where at least one ticket wins a prize.
+
+The validated release budget is deliberately shallow and reproducible:
+
+```text
+2 search passes
+4 bound-ranked candidates evaluated exactly per pass
+1 deterministic exploration candidate per pass
+```
+
+If the starting Coverage portfolio already has the exact/global-optimal Division-4-or-better certificate, the search is not allowed to lose it.
+
+Independent confirmation used 16 new 10-game Coverage portfolios rooted at seed `20260823`:
+
+- 11/16 improved and 5/16 were unchanged;
+- no portfolio worsened;
+- mean gain: **91.75 exact winning-main sets**;
+- mean exact any-prize gain: about **+0.001126 percentage points**;
+- paired portfolio-seed bootstrap 95% interval: about **+0.000636 to +0.001664 points**;
+- every existing Division-4+ global-optimality certificate was preserved.
+
+**Coverage remains the fast balanced default.** `exact-local` is an optional higher-compute refinement. It is guaranteed non-worse than its own Coverage start under the exact any-prize objective, but it is not proof of the globally optimal portfolio.
+
 ## v2.1.3 highlights
 
 ### Exact fixed-portfolio any-prize probability
@@ -110,7 +137,8 @@ That reaches the universal sum-of-marginals upper bound, so the portfolio is glo
 
 The CLI keeps objectives explicit instead of pretending one heuristic is universally best:
 
-- `coverage` — generic quadruple → triple → pair subset diversity; **recommended balanced default**;
+- `coverage` — generic quadruple → triple → pair subset diversity; **recommended fast default**;
+- `exact-local` — higher-compute exact any-prize refinement of Coverage;
 - `any-prize-bound` — greedily minimises exact pairwise `>=3 main` event-intersection cost;
 - `division4-bound` — minimises exact pairwise `>=4 main` event intersections and can return a global-optimality certificate;
 - `random` — uniform QuickPick baseline;
@@ -137,7 +165,8 @@ The Python engine now includes:
 - exact two-ticket `>=k main` event-intersection probabilities;
 - rigorous Bonferroni portfolio lower bounds;
 - exact pairwise-disjoint Division-4+ certificates;
-- **exact fixed-portfolio any-prize union probability** via complement dynamic programming.
+- **exact fixed-portfolio any-prize union probability** via complement dynamic programming;
+- **exact-guided monotonic local search** for practical Coverage portfolios.
 
 ### Data integrity
 
@@ -147,7 +176,7 @@ The Python engine now includes:
 - SHA-256 provenance for both historical CSV files;
 - saved scraper fixtures for markup-regression tests;
 - scheduled refresh refuses to publish new data when secondary verification fails;
-- migration-aware refresh rebuilds old schema assets even when the CSV itself did not change.
+- migration-aware refresh rebuilds old or incomplete schema-v3 assets even when the CSV itself did not change.
 
 ### Web application
 
@@ -167,6 +196,7 @@ The GitHub Pages site includes:
 - data freshness and provenance display;
 - dedicated Benchmark Lab with client-side multi-seed exploratory runs;
 - **exact any-prize probability for the generated 10-game reference Coverage portfolio**;
+- **exact-local reference improvement/non-worsening display**;
 - Bonferroni and Division-4 certificates shown separately from simulations;
 - system/light/dark themes;
 - offline/PWA cache support.
@@ -188,18 +218,21 @@ PYTHONPATH=src python -m lotto_lab validate
 PYTHONPATH=src python -m lotto_lab stats
 
 PYTHONPATH=src python -m lotto_lab tickets --count 10 --mode coverage
+PYTHONPATH=src python -m lotto_lab tickets --count 10 --mode exact-local --json
 PYTHONPATH=src python -m lotto_lab tickets --count 10 --mode any-prize-bound --json
 PYTHONPATH=src python -m lotto_lab tickets --count 10 --mode division4-bound --json
 PYTHONPATH=src python -m lotto_lab tickets --count 10 --mode random
 PYTHONPATH=src python -m lotto_lab tickets --count 10 --mode anti-crowding
 
 PYTHONPATH=src python -m lotto_lab exact-any-prize --count 10 --mode coverage
-PYTHONPATH=src python -m lotto_lab exact-any-prize --count 10 --mode any-prize-bound
+PYTHONPATH=src python -m lotto_lab exact-any-prize --count 10 --mode exact-local
+PYTHONPATH=src python -m lotto_lab optimize-any-prize --count 10 --seed exact-local-example
 
 PYTHONPATH=src python -m lotto_lab simulate --count 10 --trials 50000
 PYTHONPATH=src python -m lotto_lab benchmark --count 10 --coverage-portfolios 50 --random-portfolios 200 --trials 5000
 PYTHONPATH=src python -m lotto_lab benchmark-objectives --count 10 --portfolios 24 --random-portfolios 96 --trials 5000
 PYTHONPATH=src python -m lotto_lab benchmark-exact-objectives --count 10 --portfolios 32 --random-portfolios 128
+PYTHONPATH=src python -m lotto_lab benchmark-local-search --count 10 --portfolios 16 --seed 20260823
 PYTHONPATH=src python -m lotto_lab backtest --count 10 --steps 120
 PYTHONPATH=src python -m lotto_lab verify-secondary --latest 10
 ```
@@ -214,7 +247,7 @@ The scheduled workflow runs after the Saturday draw. It:
 2. determines whether draw data or generated assets need rebuilding;
 3. cross-checks the newest draws against an independent source;
 4. stops on disagreement;
-5. rebuilds schema-v3 statistics, probability certificates, the exact 10-game reference any-prize result and SHA-256 provenance;
+5. rebuilds schema-v3 statistics, exact reference portfolio evidence, the exact-local refinement and SHA-256 provenance;
 6. commits only verified changes directly to `main`.
 
 It does not create recurring update branches or automated pull requests.
@@ -223,7 +256,7 @@ It does not create recurring update branches or automated pull requests.
 
 CI runs Ruff, Python compilation, the unit suite, tracked-dataset/stat regeneration, JSON validation, browser JavaScript syntax checks and static-site reference tests.
 
-v2.1.3 also has an exact confirmation workflow for probability-engine changes. It evaluates the larger 32/32/32/128 portfolio distribution so small-seed results are not promoted without confirmation.
+The exact confirmation and exact-local workflows keep the more expensive release evidence separate from ordinary fast unit checks. Exact-local development and confirmation use different root seeds.
 
 ```bash
 ruff check src tests

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,8 +44,11 @@ This is the living engineering/research tracker. The governing rule is: **improv
 - [x] Add a Division-4-bound objective that can return a global-optimality certificate.
 - [x] Keep generic subset-diversity Coverage as a separate objective rather than silently replacing it.
 - [x] Evaluate completed portfolios with the exact any-prize union rather than only a second-order bound.
-- [ ] **Next priority:** benchmark stronger search methods — local search / simulated annealing / constraint or integer optimisation — using the exact any-prize evaluator as the final objective for practical ticket counts.
-- [ ] Explore swap/neighbourhood search starting from Coverage and bound-driven portfolios rather than random restarts only.
+- [x] Implement one-swap exact-guided local search starting from Coverage.
+- [x] Use the Bonferroni bound only for screening and require the full exact DP for acceptance.
+- [x] Preserve an existing Division-4+ global-optimality certificate during exact-local search.
+- [x] Confirm exact-local on an independent root seed after freezing the search budget.
+- [ ] Benchmark simulated annealing / larger neighbourhoods / constraint or integer optimisation against exact-local and Coverage.
 - [ ] Investigate symmetry reduction / canonical portfolio representations to avoid evaluating equivalent portfolio structures repeatedly.
 - [ ] Determine whether a provable or tightly bounded global optimum is tractable for useful 10-game any-prize portfolios.
 - [ ] Determine useful ticket-count ranges where a pairwise-disjoint ≥4-main packing can be constructed reliably.
@@ -66,8 +69,25 @@ This is the living engineering/research tracker. The governing rule is: **improv
 - [x] Add larger exact confirmation benchmark: 32 seeds per structured strategy vs 128 QuickPick seeds.
 - [x] Preserve the smaller favourable 12-seed result while using the larger confirmation run for the release recommendation.
 - [x] Confirm a strong exact Coverage-vs-QuickPick any-prize difference in the fixed 10-game benchmark.
+- [x] Add paired exact-local development and independent confirmation benchmarks.
 - [ ] Add nested resampling where strategy metrics still depend on simulated draw samples; it is unnecessary for exact any-prize probabilities.
 - [ ] Add benchmark regression thresholds only after enough exact benchmark releases establish stable expected ranges.
+
+### v2.1.4 exact-local confirmation finding
+
+The exact-local release budget was frozen at **2 search passes / 4 bound-ranked exact candidates / 1 exploration candidate** before the independent confirmation run.
+
+On 16 new 10-game Coverage portfolios rooted at seed `20260823`:
+
+- **11/16 portfolios improved** and **5/16 were unchanged**;
+- mean gain: **91.75 exact any-prize winning-main sets**;
+- mean exact probability gain: about **+0.001126 percentage points**;
+- paired portfolio-seed bootstrap 95% interval: about **+0.000636 to +0.001664 points**;
+- no portfolio worsened;
+- all existing Division-4+ global-optimality certificates were preserved;
+- Division 1 remained exactly unchanged.
+
+Coverage remains the fast balanced default. Exact-local is an optional higher-compute local refinement, not a proof of the global any-prize optimum.
 
 ### v2.1.3 exact confirmation finding
 
@@ -100,7 +120,7 @@ Division 1 remains exactly equal for all same-sized sets of distinct standard ga
 - [x] Block scheduled publication on newest-draw disagreement.
 - [x] Data-health/freshness status in dashboard.
 - [x] Saved known-draw parser fixtures.
-- [x] Migration-aware regeneration when data assets use an older schema.
+- [x] Migration-aware regeneration when data assets use an older or incomplete schema-v3 payload.
 - [ ] Prefer an official/regulator machine-readable source if one becomes reliably available.
 - [ ] Persist primary source URL/draw ID per historical row rather than only verification metadata for recent draws.
 
@@ -132,7 +152,8 @@ Division 1 remains exactly equal for all same-sized sets of distinct standard ga
 - [x] PWA shortcut to the Benchmark Lab.
 - [x] Certified Probability panel separating exact bounds from Monte Carlo evidence.
 - [x] Promote exact reference any-prize probability above the older Bonferroni bound in Benchmark Lab.
-- [x] Version the service-worker cache so v2.1.3 evidence UI replaces stale cached v2.1.2 assets.
+- [x] Show the generated exact-local reference improvement/non-worsening result.
+- [x] Version the service-worker cache for v2.1.4 evidence UI.
 - [ ] Add richer accessible SVG charts and comparison views.
 - [ ] Add explicit PWA install/update UI.
 - [ ] Add Playwright browser smoke tests on a stable CI runner.
@@ -147,10 +168,14 @@ Division 1 remains exactly equal for all same-sized sets of distinct standard ga
 - [ ] Multiple-testing controls and clear exploratory/confirmatory labelling.
 - [ ] Automated alert only for persistent, independently reproduced anomalies — never as a betting signal by default.
 
-## v3 — Reusable lottery research platform
+## v3 — Reusable Australian lottery research platform
 
-- [ ] Game-definition layer for other Australian lottery formats.
+- [ ] Game-definition layer for distinct Australian lottery mechanics.
+- [ ] Add The Lott catalog definitions: Saturday Lotto / Weekday Windfall, Oz Lotto, Powerball, Set for Life, Super 66, Lotto Strike, Lucky Lotteries and Keno.
+- [ ] Keep jurisdiction-limited games explicit rather than pretending every game is available nationally.
+- [ ] Reusable one-pool, two-pool, ordered-digit, ordered-draw, raffle-pool and Keno/spot probability engines.
 - [ ] Reusable prize-category definitions.
+- [ ] Separate alternative operators/products from The Lott and label eligibility/jurisdiction.
 - [ ] Source adapters with provenance contracts.
 - [ ] Reproducible research exports/notebooks.
 - [ ] Optional fully static precomputed benchmark datasets.

--- a/assets/certificates.js
+++ b/assets/certificates.js
@@ -6,20 +6,62 @@
       minimumFractionDigits: digits,
       maximumFractionDigits: digits,
     }).format(Number(value) || 0);
+  const pp = (value, digits = 4) => `${(Number(value || 0) * 100).toFixed(digits)} pp`;
 
   const setText = (id, value) => {
     const element = document.getElementById(id);
     if (element) element.textContent = value;
   };
 
+  function ensureLocalCard() {
+    let card = document.getElementById('cert-local-card');
+    if (card) return card;
+    const grid = document.querySelector('#certificates .planner-kpis');
+    if (!grid) return null;
+    card = document.createElement('article');
+    card.className = 'result-card glass accent';
+    card.id = 'cert-local-card';
+    card.innerHTML = `
+      <div class="console-head"><span>Exact-local refinement</span><span class="badge" id="cert-local-badge">CHECKING</span></div>
+      <strong id="cert-local-final">Loading…</strong>
+      <small id="cert-local-status">Comparing against the same Coverage start…</small>
+    `;
+    grid.append(card);
+    return card;
+  }
+
   function renderPending() {
     setText('cert-any-exact', 'Pending stats refresh');
-    setText('cert-any-exact-status', 'Exact v2.1.3 reference result not published yet');
+    setText('cert-any-exact-status', 'Exact reference result not published yet');
     setText('cert-any-lower', 'Pending stats refresh');
     setText('cert-any-upper', '—');
     setText('cert-d4-exact', 'Pending stats refresh');
     setText('cert-d4-status', '—');
     setText('cert-overlap', '—');
+    ensureLocalCard();
+    setText('cert-local-final', 'Pending stats refresh');
+    setText('cert-local-status', 'Exact-local v2.1.4 reference result not published yet');
+    setText('cert-local-badge', 'PENDING');
+  }
+
+  function renderLocalSearch(stats) {
+    ensureLocalCard();
+    const local = stats?.referenceExactLocalSearch;
+    const finalExact = local?.finalExactAnyPrize;
+    if (!local || !finalExact?.exact) {
+      setText('cert-local-final', 'Pending stats refresh');
+      setText('cert-local-status', 'Exact-local v2.1.4 reference result not published yet');
+      setText('cert-local-badge', 'PENDING');
+      return;
+    }
+
+    const improvedSets = Number(local.improvementWinningMainSets || 0);
+    setText('cert-local-final', pct(finalExact.probability, 4));
+    setText(
+      'cert-local-status',
+      `${improvedSets > 0 ? '+' : ''}${nf.format(improvedSets)} exact winning-main sets · ${improvedSets > 0 ? '+' : ''}${pp(local.improvementProbability)} · ${nf.format(local.acceptedMoves || 0)} accepted move${Number(local.acceptedMoves) === 1 ? '' : 's'}`,
+    );
+    setText('cert-local-badge', improvedSets > 0 ? 'IMPROVED' : 'NON-WORSE');
   }
 
   function renderCertificates(stats) {
@@ -43,7 +85,7 @@
       );
     } else {
       setText('cert-any-exact', 'Pending stats refresh');
-      setText('cert-any-exact-status', 'Exact v2.1.3 reference result not published yet');
+      setText('cert-any-exact-status', 'Exact reference result not published yet');
     }
 
     setText('cert-any-lower', pct(anyPrize.bonferroniLowerBound, 4));
@@ -67,6 +109,7 @@
     if (badge) {
       badge.textContent = division4.globallyOptimalForTicketCount ? 'PROVED OPTIMAL' : 'BOUND ONLY';
     }
+    renderLocalSearch(stats);
   }
 
   async function load() {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'saturday-lotto-lab-v2-1-3';
+const CACHE_NAME = 'saturday-lotto-lab-v2-1-4';
 const STATIC_ASSETS = [
   './',
   './index.html',

--- a/src/lotto_lab/__init__.py
+++ b/src/lotto_lab/__init__.py
@@ -1,3 +1,3 @@
 """Saturday Lotto Lab probability and coverage toolkit."""
 
-__version__ = "2.1.3"
+__version__ = "2.1.4"

--- a/src/lotto_lab/analysis.py
+++ b/src/lotto_lab/analysis.py
@@ -7,6 +7,7 @@ from itertools import combinations
 
 from .benchmark import benchmark_portfolio_distributions
 from .domain import BALL_COUNT, DIVISION_ONE_COMBINATIONS, MAIN_COUNT, SUPPLEMENTARY_COUNT, Draw
+from .optimizer import optimise_any_prize_exact
 from .portfolio import exact_any_prize_probability
 from .probability import (
     any_prize_probability,
@@ -74,6 +75,16 @@ def build_statistics(draws: Sequence[Draw], *, generated_at: datetime | None = N
     reference_seed = f"{ordered[-1].date.isoformat()}:{draw_count}:coverage-v3"
     reference_tickets = generate_coverage_tickets(10, seed=reference_seed)
     reference_exact_any_prize = exact_any_prize_probability(reference_tickets)
+    reference_local_search = optimise_any_prize_exact(
+        reference_tickets,
+        seed=f"{reference_seed}:exact-local-v214",
+        iterations=2,
+        exact_shortlist=4,
+        exploration_candidates=1,
+        preserve_division4_optimality=True,
+    )
+    reference_local_tickets = [tuple(ticket) for ticket in reference_local_search["tickets"]]
+    reference_local_search["metrics"] = ticket_metrics(reference_local_tickets)
     match_distribution = main_match_distribution()
     system_rows = [
         {
@@ -140,6 +151,16 @@ def build_statistics(draws: Sequence[Draw], *, generated_at: datetime | None = N
                 "Coverage mode maximises new 4-, 3- and 2-number subsets across multiple entries. "
                 "It does not change the odds of any individual six-number combination. The any-prize "
                 "probability shown here is exact for this fixed reference portfolio."
+            ),
+        },
+        "referenceExactLocalSearch": {
+            **reference_local_search,
+            "seed": f"{reference_seed}:exact-local-v214",
+            "note": (
+                "Exact-local starts from the reference Coverage portfolio, screens one-number swaps with "
+                "cheap combinatorial bounds, and accepts only exact any-prize improvements. Existing "
+                "Division-4+ global-optimality is preserved when present. It is a local refinement, not "
+                "a proof of the globally optimal any-prize portfolio."
             ),
         },
         "referenceSimulation": compare_strategies(10, trials=20_000, seed=20260822),

--- a/src/lotto_lab/cli.py
+++ b/src/lotto_lab/cli.py
@@ -148,9 +148,9 @@ def build_parser() -> argparse.ArgumentParser:
     optimise.add_argument("--count", type=int, default=10)
     optimise.add_argument("--seed", default="exact-local-v214")
     optimise.add_argument("--candidates-per-ticket", type=int, default=320)
-    optimise.add_argument("--iterations", type=int, default=3)
-    optimise.add_argument("--exact-shortlist", type=int, default=5)
-    optimise.add_argument("--exploration-candidates", type=int, default=2)
+    optimise.add_argument("--iterations", type=int, default=2)
+    optimise.add_argument("--exact-shortlist", type=int, default=4)
+    optimise.add_argument("--exploration-candidates", type=int, default=1)
 
     simulate = sub.add_parser("simulate", help="Monte Carlo comparison of coverage vs QuickPick")
     simulate.add_argument("--count", type=int, default=10)

--- a/src/lotto_lab/cli.py
+++ b/src/lotto_lab/cli.py
@@ -10,9 +10,11 @@ from .benchmark import benchmark_portfolio_distributions, benchmark_probability_
 from .crowding import generate_anti_crowding_tickets
 from .data import load_draws, write_draws
 from .exact_benchmark import benchmark_exact_any_prize_objectives
+from .optimizer import generate_exact_local_tickets, optimise_any_prize_exact
 from .portfolio import exact_any_prize_probability
 from .provenance import build_provenance, write_provenance
 from .scrape import refresh_dataset
+from .search_benchmark import benchmark_exact_local_search
 from .simulation import compare_strategies, walk_forward_backtest
 from .tickets import (
     generate_any_prize_bound_tickets,
@@ -81,6 +83,12 @@ def _probability_mode_tickets(
             seed=seed,
             candidates_per_ticket=candidates_per_ticket,
         )
+    if mode == "exact-local":
+        return generate_exact_local_tickets(
+            count,
+            seed=seed,
+            candidates_per_ticket=candidates_per_ticket,
+        )
     if mode == "random":
         return generate_random_tickets(count, seed=seed)
     raise ValueError(f"unsupported probability mode: {mode}")
@@ -111,6 +119,7 @@ def build_parser() -> argparse.ArgumentParser:
             "coverage",
             "any-prize-bound",
             "division4-bound",
+            "exact-local",
             "random",
             "anti-crowding",
         ),
@@ -126,11 +135,22 @@ def build_parser() -> argparse.ArgumentParser:
     exact.add_argument("--count", type=int, default=10)
     exact.add_argument(
         "--mode",
-        choices=("coverage", "any-prize-bound", "division4-bound", "random"),
+        choices=("coverage", "any-prize-bound", "division4-bound", "exact-local", "random"),
         default="coverage",
     )
-    exact.add_argument("--seed", default="exact-any-prize-v213")
+    exact.add_argument("--seed", default="exact-any-prize-v214")
     exact.add_argument("--candidates-per-ticket", type=int, default=320)
+
+    optimise = sub.add_parser(
+        "optimize-any-prize",
+        help="Improve a Coverage portfolio with exact-DP monotonic local search",
+    )
+    optimise.add_argument("--count", type=int, default=10)
+    optimise.add_argument("--seed", default="exact-local-v214")
+    optimise.add_argument("--candidates-per-ticket", type=int, default=320)
+    optimise.add_argument("--iterations", type=int, default=3)
+    optimise.add_argument("--exact-shortlist", type=int, default=5)
+    optimise.add_argument("--exploration-candidates", type=int, default=2)
 
     simulate = sub.add_parser("simulate", help="Monte Carlo comparison of coverage vs QuickPick")
     simulate.add_argument("--count", type=int, default=10)
@@ -171,6 +191,19 @@ def build_parser() -> argparse.ArgumentParser:
     exact_objectives.add_argument("--seed", type=int, default=20260822)
     exact_objectives.add_argument("--candidates-per-ticket", type=int, default=320)
     exact_objectives.add_argument("--bootstrap-resamples", type=int, default=2000)
+
+    local_benchmark = sub.add_parser(
+        "benchmark-local-search",
+        help="Paired exact benchmark of Coverage vs exact-guided local search",
+    )
+    local_benchmark.add_argument("--count", type=int, default=10)
+    local_benchmark.add_argument("--portfolios", type=int, default=8)
+    local_benchmark.add_argument("--seed", type=int, default=20260822)
+    local_benchmark.add_argument("--candidates-per-ticket", type=int, default=320)
+    local_benchmark.add_argument("--iterations", type=int, default=2)
+    local_benchmark.add_argument("--exact-shortlist", type=int, default=4)
+    local_benchmark.add_argument("--exploration-candidates", type=int, default=1)
+    local_benchmark.add_argument("--bootstrap-resamples", type=int, default=1200)
 
     backtest = sub.add_parser("backtest", help="Leakage-free historical portfolio-structure comparison")
     backtest.add_argument("--count", type=int, default=10)
@@ -213,6 +246,7 @@ def main(argv: list[str] | None = None) -> int:
             "coverage": generate_coverage_tickets,
             "any-prize-bound": generate_any_prize_bound_tickets,
             "division4-bound": generate_division4_bound_tickets,
+            "exact-local": generate_exact_local_tickets,
             "random": generate_random_tickets,
             "anti-crowding": generate_anti_crowding_tickets,
         }
@@ -264,6 +298,24 @@ def main(argv: list[str] | None = None) -> int:
         print(json.dumps(payload, indent=2))
         return 0
 
+    if args.command == "optimize-any-prize":
+        baseline = generate_coverage_tickets(
+            args.count,
+            seed=args.seed,
+            candidates_per_ticket=args.candidates_per_ticket,
+        )
+        result = optimise_any_prize_exact(
+            baseline,
+            seed=f"{args.seed}:search",
+            iterations=args.iterations,
+            exact_shortlist=args.exact_shortlist,
+            exploration_candidates=args.exploration_candidates,
+            preserve_division4_optimality=True,
+        )
+        result["baselineTickets"] = [list(ticket) for ticket in baseline]
+        print(json.dumps(result, indent=2))
+        return 0
+
     if args.command == "simulate":
         print(json.dumps(compare_strategies(args.count, trials=args.trials, seed=args.seed), indent=2))
         return 0
@@ -301,6 +353,20 @@ def main(argv: list[str] | None = None) -> int:
             random_portfolios=args.random_portfolios,
             seed=args.seed,
             candidates_per_ticket=args.candidates_per_ticket,
+            bootstrap_resamples=args.bootstrap_resamples,
+        )
+        print(json.dumps(result, indent=2))
+        return 0
+
+    if args.command == "benchmark-local-search":
+        result = benchmark_exact_local_search(
+            args.count,
+            portfolios=args.portfolios,
+            seed=args.seed,
+            candidates_per_ticket=args.candidates_per_ticket,
+            iterations=args.iterations,
+            exact_shortlist=args.exact_shortlist,
+            exploration_candidates=args.exploration_candidates,
             bootstrap_resamples=args.bootstrap_resamples,
         )
         print(json.dumps(result, indent=2))

--- a/src/lotto_lab/optimizer.py
+++ b/src/lotto_lab/optimizer.py
@@ -8,6 +8,8 @@ from .domain import BALL_COUNT, MAIN_COUNT
 from .portfolio import exact_any_prize_probability, portfolio_probability_certificate
 from .tickets import Ticket, generate_coverage_tickets, subset_coverage
 
+Move = dict[str, int | list[int]]
+
 
 def _rng(seed: str | int | None) -> random.Random:
     if seed is None:
@@ -34,11 +36,11 @@ def _validate_portfolio(tickets: Sequence[Sequence[int]]) -> list[Ticket]:
     return normalized
 
 
-def _one_swap_neighbours(tickets: Sequence[Ticket]) -> list[tuple[tuple[Ticket, ...], dict[str, int]]]:
+def _one_swap_neighbours(tickets: Sequence[Ticket]) -> list[tuple[tuple[Ticket, ...], Move]]:
     """Enumerate unique portfolios reachable by one number replacement in one ticket."""
     current = tuple(tickets)
     current_set = set(current)
-    neighbours: dict[tuple[Ticket, ...], dict[str, int]] = {}
+    neighbours: dict[tuple[Ticket, ...], Move] = {}
 
     for ticket_index, ticket in enumerate(current):
         ticket_numbers = set(ticket)
@@ -52,16 +54,17 @@ def _one_swap_neighbours(tickets: Sequence[Ticket]) -> list[tuple[tuple[Ticket, 
                     continue
                 candidate = list(current)
                 candidate[ticket_index] = replacement
-                candidate_tuple = tuple(candidate)
-                canonical_portfolio = tuple(sorted(candidate_tuple))
+                canonical_portfolio = tuple(sorted(candidate))
                 if canonical_portfolio in neighbours:
                     continue
                 neighbours[canonical_portfolio] = {
-                    "ticketIndex": ticket_index,
+                    "ticketIndexBeforeCanonicalSort": ticket_index,
                     "removed": removed,
                     "added": added,
+                    "beforeTicket": list(ticket),
+                    "afterTicket": list(replacement),
                 }
-    return [(portfolio, move) for portfolio, move in neighbours.items()]
+    return list(neighbours.items())
 
 
 def _screen_score(tickets: Sequence[Ticket]) -> tuple[float, float, float, int]:
@@ -117,7 +120,7 @@ def optimise_any_prize_exact(
     screened_neighbours = 0
 
     for iteration in range(1, iterations + 1):
-        screened: list[tuple[tuple[float, float, float, int], float, tuple[Ticket, ...], dict[str, int]]] = []
+        screened: list[tuple[tuple[float, float, float, int], float, tuple[Ticket, ...], Move]] = []
         for neighbour, move in _one_swap_neighbours(portfolio):
             if require_div4_certificate:
                 division4 = portfolio_probability_certificate(neighbour, threshold=4)

--- a/src/lotto_lab/optimizer.py
+++ b/src/lotto_lab/optimizer.py
@@ -80,9 +80,9 @@ def optimise_any_prize_exact(
     tickets: Sequence[Sequence[int]],
     *,
     seed: str | int | None = None,
-    iterations: int = 3,
-    exact_shortlist: int = 5,
-    exploration_candidates: int = 2,
+    iterations: int = 2,
+    exact_shortlist: int = 4,
+    exploration_candidates: int = 1,
     preserve_division4_optimality: bool = True,
 ) -> dict:
     """Monotonic one-swap local search with exact any-prize acceptance.
@@ -194,9 +194,9 @@ def generate_exact_local_tickets(
     seed: str | int | None = None,
     *,
     candidates_per_ticket: int = 320,
-    iterations: int = 3,
-    exact_shortlist: int = 5,
-    exploration_candidates: int = 2,
+    iterations: int = 2,
+    exact_shortlist: int = 4,
+    exploration_candidates: int = 1,
 ) -> list[Ticket]:
     """Generate Coverage tickets, then improve or retain them on exact any-prize probability."""
     baseline = generate_coverage_tickets(

--- a/src/lotto_lab/optimizer.py
+++ b/src/lotto_lab/optimizer.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import hashlib
+import random
+from collections.abc import Sequence
+
+from .domain import BALL_COUNT, MAIN_COUNT
+from .portfolio import exact_any_prize_probability, portfolio_probability_certificate
+from .tickets import Ticket, generate_coverage_tickets, subset_coverage
+
+
+def _rng(seed: str | int | None) -> random.Random:
+    if seed is None:
+        return random.SystemRandom()
+    if isinstance(seed, str):
+        digest = hashlib.sha256(seed.encode("utf-8")).digest()
+        seed = int.from_bytes(digest[:16], "big")
+    return random.Random(seed)
+
+
+def _validate_portfolio(tickets: Sequence[Sequence[int]]) -> list[Ticket]:
+    normalized: list[Ticket] = []
+    for ticket in tickets:
+        canonical = tuple(sorted(ticket))
+        if len(canonical) != MAIN_COUNT or len(set(canonical)) != MAIN_COUNT:
+            raise ValueError("every ticket must contain six distinct numbers")
+        if any(number < 1 or number > BALL_COUNT for number in canonical):
+            raise ValueError("ticket numbers must be between 1 and 45")
+        normalized.append(canonical)
+    if not normalized:
+        raise ValueError("at least one ticket is required")
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("portfolio tickets must be distinct")
+    return normalized
+
+
+def _one_swap_neighbours(tickets: Sequence[Ticket]) -> list[tuple[tuple[Ticket, ...], dict[str, int]]]:
+    """Enumerate unique portfolios reachable by one number replacement in one ticket."""
+    current = tuple(tickets)
+    current_set = set(current)
+    neighbours: dict[tuple[Ticket, ...], dict[str, int]] = {}
+
+    for ticket_index, ticket in enumerate(current):
+        ticket_numbers = set(ticket)
+        for removed in ticket:
+            remaining = ticket_numbers - {removed}
+            for added in range(1, BALL_COUNT + 1):
+                if added in ticket_numbers:
+                    continue
+                replacement = tuple(sorted((*remaining, added)))
+                if replacement in current_set and replacement != ticket:
+                    continue
+                candidate = list(current)
+                candidate[ticket_index] = replacement
+                candidate_tuple = tuple(candidate)
+                canonical_portfolio = tuple(sorted(candidate_tuple))
+                if canonical_portfolio in neighbours:
+                    continue
+                neighbours[canonical_portfolio] = {
+                    "ticketIndex": ticket_index,
+                    "removed": removed,
+                    "added": added,
+                }
+    return [(portfolio, move) for portfolio, move in neighbours.items()]
+
+
+def _screen_score(tickets: Sequence[Ticket]) -> tuple[float, float, float, int]:
+    any_prize = portfolio_probability_certificate(tickets, threshold=3)
+    triples = subset_coverage(tickets, 3)
+    pairs = subset_coverage(tickets, 2)
+    return (
+        float(any_prize["bonferroniLowerBound"]),
+        float(triples["efficiency"]),
+        float(pairs["efficiency"]),
+        -int(any_prize["maximumTicketOverlap"]),
+    )
+
+
+def optimise_any_prize_exact(
+    tickets: Sequence[Sequence[int]],
+    *,
+    seed: str | int | None = None,
+    iterations: int = 3,
+    exact_shortlist: int = 5,
+    exploration_candidates: int = 2,
+    preserve_division4_optimality: bool = True,
+) -> dict:
+    """Monotonic one-swap local search with exact any-prize acceptance.
+
+    Cheap exact pair-intersection bounds screen the full one-swap neighbourhood.
+    Only shortlisted portfolios are passed to the more expensive exact dynamic
+    program. A move is accepted only when its integer favourable-set count is
+    strictly larger than the current count.
+
+    If the starting portfolio has an exact/global-optimal Division-4+ certificate,
+    that certificate is preserved by default. Equal ticket count and distinctness
+    preserve Division 1 probability automatically.
+    """
+    portfolio = _validate_portfolio(tickets)
+    if iterations < 0:
+        raise ValueError("iterations must be non-negative")
+    if exact_shortlist < 1:
+        raise ValueError("exact_shortlist must be at least 1")
+    if exploration_candidates < 0:
+        raise ValueError("exploration_candidates must be non-negative")
+
+    rng = _rng(seed)
+    baseline_exact = exact_any_prize_probability(portfolio)
+    current_exact = baseline_exact
+    baseline_div4 = portfolio_probability_certificate(portfolio, threshold=4)
+    require_div4_certificate = bool(
+        preserve_division4_optimality and baseline_div4["globallyOptimalForTicketCount"]
+    )
+
+    history: list[dict] = []
+    exact_evaluations = 1
+    screened_neighbours = 0
+
+    for iteration in range(1, iterations + 1):
+        screened: list[tuple[tuple[float, float, float, int], float, tuple[Ticket, ...], dict[str, int]]] = []
+        for neighbour, move in _one_swap_neighbours(portfolio):
+            if require_div4_certificate:
+                division4 = portfolio_probability_certificate(neighbour, threshold=4)
+                if not division4["globallyOptimalForTicketCount"]:
+                    continue
+            score = _screen_score(neighbour)
+            screened.append((score, rng.random(), neighbour, move))
+
+        screened_neighbours += len(screened)
+        if not screened:
+            break
+        screened.sort(key=lambda row: (row[0], row[1]), reverse=True)
+
+        selected = screened[:exact_shortlist]
+        remainder = screened[exact_shortlist:]
+        if exploration_candidates and remainder:
+            sample_size = min(exploration_candidates, len(remainder))
+            selected.extend(rng.sample(remainder, sample_size))
+
+        best = None
+        best_count = int(current_exact["anyPrizeWinningMainSets"])
+        for score, _tie, candidate, move in selected:
+            exact = exact_any_prize_probability(candidate)
+            exact_evaluations += 1
+            favourable_count = int(exact["anyPrizeWinningMainSets"])
+            if favourable_count > best_count:
+                best_count = favourable_count
+                best = (candidate, move, score, exact)
+
+        if best is None:
+            break
+
+        candidate, move, score, exact = best
+        before_count = int(current_exact["anyPrizeWinningMainSets"])
+        portfolio = list(candidate)
+        current_exact = exact
+        history.append(
+            {
+                "iteration": iteration,
+                "move": move,
+                "beforeAnyPrizeWinningMainSets": before_count,
+                "afterAnyPrizeWinningMainSets": best_count,
+                "improvementWinningMainSets": best_count - before_count,
+                "screenBonferroniLowerBound": score[0],
+                "exactProbability": exact["probability"],
+            }
+        )
+
+    final_div4 = portfolio_probability_certificate(portfolio, threshold=4)
+    baseline_count = int(baseline_exact["anyPrizeWinningMainSets"])
+    final_count = int(current_exact["anyPrizeWinningMainSets"])
+
+    return {
+        "tickets": [list(ticket) for ticket in portfolio],
+        "baselineExactAnyPrize": baseline_exact,
+        "finalExactAnyPrize": current_exact,
+        "improvementWinningMainSets": final_count - baseline_count,
+        "improvementProbability": (final_count - baseline_count) / int(current_exact["totalWinningMainSets"]),
+        "acceptedMoves": len(history),
+        "iterationsRequested": iterations,
+        "exactEvaluations": exact_evaluations,
+        "screenedNeighbours": screened_neighbours,
+        "preservedDivision4Optimality": (
+            not require_div4_certificate or bool(final_div4["globallyOptimalForTicketCount"])
+        ),
+        "division4CertificateWasRequired": require_div4_certificate,
+        "history": history,
+        "algorithm": "one-swap local search; Bonferroni screening; exact-DP monotonic acceptance",
+    }
+
+
+def generate_exact_local_tickets(
+    count: int,
+    seed: str | int | None = None,
+    *,
+    candidates_per_ticket: int = 320,
+    iterations: int = 3,
+    exact_shortlist: int = 5,
+    exploration_candidates: int = 2,
+) -> list[Ticket]:
+    """Generate Coverage tickets, then improve or retain them on exact any-prize probability."""
+    baseline = generate_coverage_tickets(
+        count,
+        seed=seed,
+        candidates_per_ticket=candidates_per_ticket,
+    )
+    result = optimise_any_prize_exact(
+        baseline,
+        seed=f"{seed}:exact-local" if seed is not None else None,
+        iterations=iterations,
+        exact_shortlist=exact_shortlist,
+        exploration_candidates=exploration_candidates,
+        preserve_division4_optimality=True,
+    )
+    return [tuple(ticket) for ticket in result["tickets"]]

--- a/src/lotto_lab/search_benchmark.py
+++ b/src/lotto_lab/search_benchmark.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import random
+from statistics import fmean
+
+from .benchmark import distribution_summary
+from .optimizer import optimise_any_prize_exact
+from .portfolio import exact_any_prize_probability, portfolio_probability_certificate
+from .tickets import generate_coverage_tickets
+
+
+def _quantile(values: list[float], probability: float) -> float:
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * probability
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = position - lower
+    return ordered[lower] * (1 - fraction) + ordered[upper] * fraction
+
+
+def _paired_bootstrap_mean_ci(
+    differences: list[float],
+    *,
+    resamples: int,
+    seed: int,
+) -> tuple[float, float]:
+    if not differences:
+        raise ValueError("at least one paired difference is required")
+    if resamples < 100:
+        raise ValueError("resamples must be at least 100")
+    rng = random.Random(seed)
+    means = [
+        fmean(rng.choice(differences) for _ in differences)
+        for _ in range(resamples)
+    ]
+    return _quantile(means, 0.025), _quantile(means, 0.975)
+
+
+def benchmark_exact_local_search(
+    ticket_count: int = 10,
+    *,
+    portfolios: int = 8,
+    seed: int = 20260822,
+    candidates_per_ticket: int = 320,
+    iterations: int = 2,
+    exact_shortlist: int = 4,
+    exploration_candidates: int = 1,
+    bootstrap_resamples: int = 1200,
+) -> dict:
+    """Paired exact benchmark: Coverage start vs its own exact-guided local-search result."""
+    if portfolios < 2:
+        raise ValueError("at least two portfolios are required")
+
+    rows = []
+    for index in range(portfolios):
+        coverage_seed = f"objective:{seed}:coverage:{index}"
+        baseline = generate_coverage_tickets(
+            ticket_count,
+            seed=coverage_seed,
+            candidates_per_ticket=candidates_per_ticket,
+        )
+        baseline_exact = exact_any_prize_probability(baseline)
+        baseline_div4 = portfolio_probability_certificate(baseline, threshold=4)
+        result = optimise_any_prize_exact(
+            baseline,
+            seed=f"exact-local:{seed}:{index}",
+            iterations=iterations,
+            exact_shortlist=exact_shortlist,
+            exploration_candidates=exploration_candidates,
+            preserve_division4_optimality=True,
+        )
+        final_tickets = [tuple(ticket) for ticket in result["tickets"]]
+        final_exact = result["finalExactAnyPrize"]
+        final_div4 = portfolio_probability_certificate(final_tickets, threshold=4)
+        baseline_count = int(baseline_exact["anyPrizeWinningMainSets"])
+        final_count = int(final_exact["anyPrizeWinningMainSets"])
+        if final_count < baseline_count:
+            raise AssertionError("exact local search worsened the objective")
+        if baseline_div4["globallyOptimalForTicketCount"] and not final_div4[
+            "globallyOptimalForTicketCount"
+        ]:
+            raise AssertionError("exact local search lost an existing Division-4+ optimum certificate")
+
+        rows.append(
+            {
+                "index": index,
+                "coverageSeed": coverage_seed,
+                "baselineExactAnyPrizeProbability": float(baseline_exact["probability"]),
+                "finalExactAnyPrizeProbability": float(final_exact["probability"]),
+                "improvementProbability": (final_count - baseline_count)
+                / int(final_exact["totalWinningMainSets"]),
+                "improvementWinningMainSets": final_count - baseline_count,
+                "acceptedMoves": int(result["acceptedMoves"]),
+                "exactEvaluations": int(result["exactEvaluations"]),
+                "screenedNeighbours": int(result["screenedNeighbours"]),
+                "baselineDivision4Optimal": bool(
+                    baseline_div4["globallyOptimalForTicketCount"]
+                ),
+                "finalDivision4Optimal": bool(final_div4["globallyOptimalForTicketCount"]),
+            }
+        )
+
+    improvements = [row["improvementProbability"] for row in rows]
+    improvement_counts = [float(row["improvementWinningMainSets"]) for row in rows]
+    baseline_probabilities = [row["baselineExactAnyPrizeProbability"] for row in rows]
+    final_probabilities = [row["finalExactAnyPrizeProbability"] for row in rows]
+    ci_low, ci_high = _paired_bootstrap_mean_ci(
+        improvements,
+        resamples=bootstrap_resamples,
+        seed=seed ^ 0x214E_A7C7,
+    )
+    improved = sum(value > 0 for value in improvements)
+    all_d4_preserved = all(
+        (not row["baselineDivision4Optimal"]) or row["finalDivision4Optimal"]
+        for row in rows
+    )
+
+    return {
+        "ticketCount": ticket_count,
+        "portfolioPairs": portfolios,
+        "seed": seed,
+        "candidatesPerTicket": candidates_per_ticket,
+        "iterations": iterations,
+        "exactShortlist": exact_shortlist,
+        "explorationCandidates": exploration_candidates,
+        "exact": True,
+        "pairedDesign": True,
+        "divisionOneProbabilityEqual": True,
+        "baseline": distribution_summary(baseline_probabilities),
+        "final": distribution_summary(final_probabilities),
+        "improvementProbability": distribution_summary(improvements),
+        "improvementWinningMainSets": distribution_summary(improvement_counts),
+        "pairedMeanImprovementCi95": [ci_low, ci_high],
+        "improvedPortfolioFraction": improved / portfolios,
+        "unchangedPortfolioFraction": (portfolios - improved) / portfolios,
+        "allExactImprovementsNonNegative": all(value >= 0 for value in improvements),
+        "allExistingDivision4OptimaPreserved": all_d4_preserved,
+        "rows": rows,
+        "note": (
+            "Each improved portfolio starts from its paired Coverage portfolio. Bonferroni is used "
+            "only for neighbour screening; a move is accepted only when exact dynamic-programming "
+            "evaluation increases the integer any-prize winning-main-set count. Existing exact "
+            "Division-4+ global-optimality certificates are preserved. No global any-prize optimum "
+            "is claimed."
+        ),
+    }

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -27,6 +27,16 @@ class AnalysisTests(unittest.TestCase):
         self.assertGreaterEqual(exact["probability"], certificates["anyPrize"]["bonferroniLowerBound"])
         self.assertLessEqual(exact["probability"], certificates["anyPrize"]["firstOrderUnionBound"])
 
+        local = stats["referenceExactLocalSearch"]
+        self.assertTrue(local["finalExactAnyPrize"]["exact"])
+        self.assertGreaterEqual(local["improvementWinningMainSets"], 0)
+        self.assertGreaterEqual(
+            local["finalExactAnyPrize"]["anyPrizeWinningMainSets"],
+            local["baselineExactAnyPrize"]["anyPrizeWinningMainSets"],
+        )
+        self.assertTrue(local["preservedDivision4Optimality"])
+        self.assertEqual(local["iterationsRequested"], 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_optimizer_v214.py
+++ b/tests/test_optimizer_v214.py
@@ -1,0 +1,79 @@
+import unittest
+
+from lotto_lab.optimizer import generate_exact_local_tickets, optimise_any_prize_exact
+from lotto_lab.portfolio import exact_any_prize_probability, portfolio_probability_certificate
+from lotto_lab.tickets import generate_coverage_tickets
+
+
+class ExactLocalSearchV214Tests(unittest.TestCase):
+    def test_local_search_never_worsens_exact_any_prize_probability(self):
+        baseline = generate_coverage_tickets(6, seed="local-monotonic", candidates_per_ticket=40)
+        result = optimise_any_prize_exact(
+            baseline,
+            seed="local-monotonic-search",
+            iterations=1,
+            exact_shortlist=2,
+            exploration_candidates=0,
+        )
+        self.assertGreaterEqual(
+            result["finalExactAnyPrize"]["anyPrizeWinningMainSets"],
+            result["baselineExactAnyPrize"]["anyPrizeWinningMainSets"],
+        )
+        for step in result["history"]:
+            self.assertGreater(
+                step["afterAnyPrizeWinningMainSets"],
+                step["beforeAnyPrizeWinningMainSets"],
+            )
+
+    def test_local_search_preserves_existing_division4_global_certificate(self):
+        baseline = [
+            (1, 2, 3, 4, 5, 6),
+            (7, 8, 9, 10, 11, 12),
+            (13, 14, 15, 16, 17, 18),
+            (19, 20, 21, 22, 23, 24),
+        ]
+        self.assertTrue(
+            portfolio_probability_certificate(baseline, threshold=4)["globallyOptimalForTicketCount"]
+        )
+        result = optimise_any_prize_exact(
+            baseline,
+            seed="preserve-d4",
+            iterations=1,
+            exact_shortlist=2,
+            exploration_candidates=0,
+        )
+        final = [tuple(ticket) for ticket in result["tickets"]]
+        self.assertTrue(result["preservedDivision4Optimality"])
+        self.assertTrue(
+            portfolio_probability_certificate(final, threshold=4)["globallyOptimalForTicketCount"]
+        )
+
+    def test_generator_is_deterministic_and_returns_distinct_tickets(self):
+        kwargs = {
+            "candidates_per_ticket": 40,
+            "iterations": 1,
+            "exact_shortlist": 2,
+            "exploration_candidates": 0,
+        }
+        left = generate_exact_local_tickets(5, seed="deterministic-local", **kwargs)
+        right = generate_exact_local_tickets(5, seed="deterministic-local", **kwargs)
+        self.assertEqual(left, right)
+        self.assertEqual(len(left), len(set(left)))
+        self.assertEqual(len(left), 5)
+
+    def test_zero_iterations_returns_same_exact_probability(self):
+        baseline = generate_coverage_tickets(5, seed="zero-local", candidates_per_ticket=40)
+        result = optimise_any_prize_exact(baseline, iterations=0)
+        exact = exact_any_prize_probability(baseline)
+        self.assertEqual(result["finalExactAnyPrize"], exact)
+        self.assertEqual(result["improvementWinningMainSets"], 0)
+        self.assertEqual(result["acceptedMoves"], 0)
+
+    def test_duplicate_portfolio_is_rejected(self):
+        ticket = (1, 2, 3, 4, 5, 6)
+        with self.assertRaises(ValueError):
+            optimise_any_prize_exact([ticket, ticket], iterations=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_search_benchmark_v214.py
+++ b/tests/test_search_benchmark_v214.py
@@ -1,0 +1,28 @@
+import unittest
+
+from lotto_lab.search_benchmark import benchmark_exact_local_search
+
+
+class SearchBenchmarkV214Tests(unittest.TestCase):
+    def test_paired_benchmark_never_reports_negative_exact_improvement(self):
+        result = benchmark_exact_local_search(
+            5,
+            portfolios=2,
+            seed=214,
+            candidates_per_ticket=40,
+            iterations=1,
+            exact_shortlist=1,
+            exploration_candidates=0,
+            bootstrap_resamples=100,
+        )
+        self.assertTrue(result["exact"])
+        self.assertTrue(result["pairedDesign"])
+        self.assertTrue(result["divisionOneProbabilityEqual"])
+        self.assertTrue(result["allExactImprovementsNonNegative"])
+        self.assertTrue(result["allExistingDivision4OptimaPreserved"])
+        self.assertGreaterEqual(result["improvementProbability"]["min"], 0)
+        self.assertEqual(result["portfolioPairs"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## v2.1.4 — Exact-guided local portfolio search

This release adds a conservative higher-compute refinement on top of the v2.1.3 exact evaluator.

### Algorithm
- start from the existing 10-game Coverage portfolio;
- enumerate one-number swap neighbours;
- use the exact pair-intersection/Bonferroni score only to screen the large neighbourhood;
- evaluate a small fixed shortlist with the full exact any-prize dynamic program;
- accept a mutation **only** when the integer number of any-prize winning-main sets strictly increases;
- preserve an existing Division-4-or-better global-optimality certificate by default;
- keep ticket count/distinctness fixed, so Division 1 probability is unchanged.

The validated release search budget is frozen at **2 passes / 4 bound-ranked exact candidates / 1 exploration candidate**. The CLI and generator defaults now match that tested configuration.

### Independent confirmation
Development used root seed `20260822`. After freezing the budget, the confirmation benchmark used a different root seed, `20260823`, with 16 new Coverage starts.

Results:
- **11/16 improved**, 5/16 unchanged, 0 worsened;
- mean gain: **91.75 exact winning-main sets**;
- mean exact any-prize gain: **+0.001126 percentage points**;
- paired portfolio-seed bootstrap 95% interval: about **+0.000636 to +0.001664 points**;
- every existing Division-4+ global-optimality certificate was preserved;
- Division 1 remained exactly unchanged.

A previous development run improved 7/12 portfolios with a larger mean gain; the independent holdout is the release result and is intentionally used instead of the more favourable development magnitude.

### Product position
**Coverage remains the fast balanced default.** `exact-local` is an optional higher-compute refinement for practical smaller portfolios. It is non-worse than its own Coverage starting point by construction on the exact any-prize objective, but it is **not** proof of a globally optimal portfolio.

### Integration
- `tickets --mode exact-local`;
- `exact-any-prize --mode exact-local`;
- `optimize-any-prize` with full before/after and accepted-move audit trail;
- `benchmark-local-search` paired exact benchmark;
- generated `referenceExactLocalSearch` statistics;
- Benchmark Lab dynamically displays exact-local final probability, exact additional winning sets and accepted moves;
- service-worker cache bumped to v2.1.4;
- scheduled refresh treats schema-v3 stats missing the v2.1.4 exact-local reference as stale and forces verified regeneration;
- package version / README / changelog / roadmap updated.

### Guardrails
- no simulated outcomes train or accept mutations;
- exact integer winning-set count is the final acceptance criterion;
- existing certified Division-4 optimum is not traded away;
- equal-size portfolios retain identical Division 1 odds;
- no historical hot/cold/recency signal enters the optimiser;
- local improvement is not presented as global optimality or future-draw prediction.

### Validation
- development exact benchmark: passed;
- independent 16-pair holdout: passed;
- Ruff / compilation / unit tests: release-gated in CI;
- full stats/provenance regeneration and browser/static checks: release-gated in CI;
- historical CSV files are intentionally unchanged.

Roadmap issue #17 remains open. After this release the next platform phase is a game-definition layer for other Australian lottery mechanics (Powerball, Oz Lotto, Set for Life, Super 66, Lotto Strike, Lucky Lotteries, Keno, and non-The-Lott alternatives such as Lotterywest Cash 3), with operator/jurisdiction provenance kept explicit.