### PR TITLE
UI polish: align PWA theme and favicon

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,35 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
-  <defs>
-    <linearGradient id="grad1" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#2563eb;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#1d4ed8;stop-opacity:1" />
-    </linearGradient>
-    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
-      <feDropShadow dx="1" dy="1" stdDeviation="1" flood-color="#000000" flood-opacity="0.3"/>
-    </filter>
-  </defs>
-  
-  <!-- Background circle with shadow -->
-  <circle cx="16" cy="16" r="15" fill="url(#grad1)" stroke="#1e40af" stroke-width="1" filter="url(#shadow)"/>
-  
-  <!-- Dice with better visibility -->
-  <rect x="8" y="8" width="8" height="8" rx="1" fill="white" opacity="0.95" stroke="#2563eb" stroke-width="0.5"/>
-  <circle cx="10" cy="10" r="1" fill="#2563eb"/>
-  <circle cx="14" cy="14" r="1" fill="#2563eb"/>
-  <circle cx="10" cy="14" r="1" fill="#2563eb"/>
-  <circle cx="14" cy="10" r="1" fill="#2563eb"/>
-  
-  <!-- Chart bars with better contrast -->
-  <rect x="18" y="20" width="2" height="6" fill="white" opacity="0.9"/>
-  <rect x="21" y="18" width="2" height="8" fill="white" opacity="0.9"/>
-  <rect x="24" y="22" width="2" height="4" fill="white" opacity="0.9"/>
-  
-  <!-- Enhanced sparkles -->
-  <circle cx="22" cy="8" r="0.8" fill="white" opacity="0.9"/>
-  <circle cx="26" cy="12" r="0.6" fill="white" opacity="0.8"/>
-  <circle cx="20" cy="6" r="0.4" fill="white" opacity="0.7"/>
-  
-  <!-- Additional decorative elements -->
-  <circle cx="6" cy="26" r="0.5" fill="white" opacity="0.6"/>
-  <circle cx="28" cy="6" r="0.5" fill="white" opacity="0.6"/>
-</svg> 
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Lottery Lab">
+  <rect width="32" height="32" rx="7" fill="#0b6b4f"/>
+  <circle cx="16" cy="16" r="9.5" fill="none" stroke="#ffffff" stroke-width="1.5"/>
+  <text x="16" y="21" text-anchor="middle" fill="#ffffff" font-family="ui-sans-serif,system-ui,sans-serif" font-size="15" font-weight="700">6</text>
+</svg>

--- a/assets/site.webmanifest
+++ b/assets/site.webmanifest
@@ -1,12 +1,12 @@
 {
-  "name": "Australian Lottery Probability Lab",
+  "name": "Lottery Lab",
   "short_name": "Lottery Lab",
-  "description": "Exact probability, portfolio research and operator-aware game mechanics for Australian lotteries.",
+  "description": "Australian lottery probability, portfolio and game-mechanics research.",
   "start_url": "./",
   "scope": "./",
   "display": "standalone",
-  "background_color": "#07101f",
-  "theme_color": "#07101f",
+  "background_color": "#f5f6f3",
+  "theme_color": "#f5f6f3",
   "icons": [
     {
       "src": "favicon.svg",
@@ -17,15 +17,15 @@
   ],
   "shortcuts": [
     {
-      "name": "Games & Odds Lab",
+      "name": "Games & Odds",
       "short_name": "Games",
-      "description": "Compare The Lott, Lotterywest and distinct Australian lottery mechanics.",
+      "description": "Compare Australian lottery mechanics and current sourced odds.",
       "url": "../games.html"
     },
     {
-      "name": "Multi-seed Benchmark",
-      "short_name": "Benchmark",
-      "description": "Compare Saturday Lotto coverage portfolios against QuickPick distributions.",
+      "name": "Saturday Benchmarks",
+      "short_name": "Benchmarks",
+      "description": "Open exact and multi-seed Saturday Lotto portfolio evidence.",
       "url": "../benchmark.html"
     }
   ]

--- a/tests/test_ui_redesign.py
+++ b/tests/test_ui_redesign.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from pathlib import Path
 
@@ -43,6 +44,19 @@ class UiRedesignTests(unittest.TestCase):
         for name in ("assets/games.css", "assets/benchmark.css"):
             css = (ROOT / name).read_text(encoding="utf-8")
             self.assertLess(len(css), 500, name)
+
+    def test_pwa_metadata_matches_neutral_redesign(self):
+        manifest = json.loads((ROOT / "assets/site.webmanifest").read_text(encoding="utf-8"))
+        self.assertEqual(manifest["name"], "Lottery Lab")
+        self.assertEqual(manifest["background_color"], "#f5f6f3")
+        self.assertEqual(manifest["theme_color"], "#f5f6f3")
+
+    def test_favicon_is_simple_and_has_no_decorative_effects(self):
+        favicon = (ROOT / "assets/favicon.svg").read_text(encoding="utf-8")
+        self.assertNotIn("linearGradient", favicon)
+        self.assertNotIn("feDropShadow", favicon)
+        self.assertNotIn("sparkle", favicon.casefold())
+        self.assertIn('fill="#0b6b4f"', favicon)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Small follow-up to the v3 UI overhaul.

- removes the old navy PWA splash/theme metadata;
- renames installed app to the simpler `Lottery Lab` identity;
- replaces the old blue gradient/dice/chart/sparkle favicon with a single flat lottery-ball mark;
- adds regression tests so install metadata and favicon cannot silently drift back to the old visual language.

No probability, data or application logic changes.