### PR TITLE
Harden production dark mode and canonical site data

### DIFF
--- a/.github/scripts/browser_audit.mjs
+++ b/.github/scripts/browser_audit.mjs
@@ -28,9 +28,10 @@ for (const [pageName, path] of pages) {
       page.on('console', message => {
         if (message.type() === 'error') consoleErrors.push(message.text());
       });
-      page.on('requestfailed', request => {
-        requestFailures.push({ url: request.url(), error: request.failure()?.errorText || 'unknown' });
-      });
+      page.on('requestfailed', request => requestFailures.push({
+        url: request.url(),
+        error: request.failure()?.errorText || 'unknown',
+      }));
 
       const url = new URL(path, base).href;
       let navigationError = null;
@@ -39,14 +40,50 @@ for (const [pageName, path] of pages) {
       } catch (error) {
         navigationError = String(error);
       }
-      await page.waitForTimeout(2500);
+      await page.waitForTimeout(1500);
 
-      const metrics = await page.evaluate(() => {
+      if (viewportName === 'mobile') {
+        const burger = page.locator('.navbar-burger');
+        if (await burger.count()) {
+          await burger.click();
+          await page.waitForTimeout(200);
+        }
+      }
+
+      const metrics = await page.evaluate(({ pageName, viewportName, theme }) => {
         const visible = element => {
           const style = getComputedStyle(element);
           const rect = element.getBoundingClientRect();
-          return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+          return style.display !== 'none' && style.visibility !== 'hidden' && Number(style.opacity) !== 0 && rect.width > 0 && rect.height > 0;
         };
+        const rgba = value => {
+          const match = value?.match(/rgba?\(([^)]+)\)/);
+          if (!match) return null;
+          const values = match[1].split(',').map(part => Number.parseFloat(part.trim()));
+          return { r: values[0], g: values[1], b: values[2], a: values.length > 3 ? values[3] : 1 };
+        };
+        const backgroundFor = element => {
+          let current = element;
+          while (current) {
+            const parsed = rgba(getComputedStyle(current).backgroundColor);
+            if (parsed && parsed.a > 0.01) return parsed;
+            current = current.parentElement;
+          }
+          return theme === 'dark' ? { r: 20, g: 22, b: 26, a: 1 } : { r: 255, g: 255, b: 255, a: 1 };
+        };
+        const luminance = colour => {
+          const channel = value => {
+            const scaled = value / 255;
+            return scaled <= 0.03928 ? scaled / 12.92 : ((scaled + 0.055) / 1.055) ** 2.4;
+          };
+          return 0.2126 * channel(colour.r) + 0.7152 * channel(colour.g) + 0.0722 * channel(colour.b);
+        };
+        const contrast = (a, b) => {
+          const x = luminance(a);
+          const y = luminance(b);
+          return (Math.max(x, y) + 0.05) / (Math.min(x, y) + 0.05);
+        };
+
         const overflow = [...document.querySelectorAll('body *')]
           .map(element => ({ element, rect: element.getBoundingClientRect() }))
           .filter(({ element, rect }) => visible(element) && (rect.right > innerWidth + 1 || rect.left < -1 || rect.width > innerWidth + 1))
@@ -55,67 +92,98 @@ for (const [pageName, path] of pages) {
             tag: element.tagName.toLowerCase(),
             id: element.id || null,
             className: typeof element.className === 'string' ? element.className : null,
-            text: (element.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 140),
-            left: Math.round(rect.left),
-            right: Math.round(rect.right),
-            width: Math.round(rect.width),
+            text: (element.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 120),
+            left: Math.round(rect.left), right: Math.round(rect.right), width: Math.round(rect.width),
           }));
+
         const skeletons = [...document.querySelectorAll('.is-skeleton,.has-skeleton,.skeleton-lines,.skeleton-block')]
           .filter(visible)
-          .map(element => ({
-            tag: element.tagName.toLowerCase(),
-            id: element.id || null,
-            className: element.className,
-            text: (element.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 140),
-          }));
-        const sample = selector => {
-          const element = document.querySelector(selector);
-          if (!element) return null;
-          const style = getComputedStyle(element);
-          return {
-            backgroundColor: style.backgroundColor,
-            color: style.color,
-            padding: style.padding,
-            margin: style.margin,
-          };
-        };
+          .map(element => ({ id: element.id || null, className: element.className, text: (element.textContent || '').trim().slice(0, 100) }));
+
+        const lowContrast = [];
+        if (theme === 'dark') {
+          const selectors = '.title,.subtitle,.label,.heading,.navbar-item,.button,.notification,.message-body,.box p,.card p,.table th,.table td';
+          [...document.querySelectorAll(selectors)].filter(visible).forEach(element => {
+            const text = (element.textContent || '').trim().replace(/\s+/g, ' ');
+            if (!text || text.length > 500) return;
+            const foreground = rgba(getComputedStyle(element).color);
+            if (!foreground) return;
+            const ratio = contrast(foreground, backgroundFor(element));
+            if (ratio < 3) lowContrast.push({
+              tag: element.tagName.toLowerCase(),
+              id: element.id || null,
+              className: element.className,
+              text: text.slice(0, 100),
+              ratio: Number(ratio.toFixed(2)),
+            });
+          });
+        }
+
+        const shadowedSurfaces = [...document.querySelectorAll('.box,.card')]
+          .filter(visible)
+          .filter(element => getComputedStyle(element).boxShadow !== 'none')
+          .slice(0, 20)
+          .map(element => ({ tag: element.tagName.toLowerCase(), id: element.id || null, className: element.className }));
+
+        const menuRects = viewportName === 'mobile'
+          ? [...document.querySelectorAll('.navbar-menu.is-active .navbar-item')].filter(visible).map(element => {
+              const rect = element.getBoundingClientRect();
+              return { text: (element.textContent || '').trim().replace(/\s+/g, ' '), top: rect.top, bottom: rect.bottom, height: rect.height };
+            })
+          : [];
+        const menuOverlap = menuRects.some((row, index) => index > 0 && row.top < menuRects[index - 1].bottom - 1);
+        const menuTooShort = menuRects.some(row => row.height < 36);
+
+        const bodyText = document.body.innerText.toLowerCase();
+        const localBulma = [...document.styleSheets].some(sheet => String(sheet.href || '').includes('/assets/vendor/bulma.min.css'));
+        const localLucide = typeof window.lucide?.createIcons === 'function';
+        const statusId = pageName === 'games' ? 'catalog-status' : 'header-data-status';
+        const statusText = (document.getElementById(statusId)?.textContent || '').trim();
+
+        const loaded = (() => {
+          if (pageName === 'saturday') {
+            const drawCount = Number((document.getElementById('metric-draws')?.textContent || '').replace(/[^0-9]/g, ''));
+            const resultCount = Number((document.getElementById('draw-result-count')?.textContent || '').replace(/[^0-9]/g, ''));
+            const frequencyRows = document.querySelectorAll('#frequency-chart tbody tr').length;
+            const drawRows = document.querySelectorAll('#draw-list article.media').length;
+            const backtestReady = !document.querySelector('#backtest-table .skeleton-lines');
+            return { ok: drawCount > 0 && resultCount > 0 && frequencyRows > 0 && drawRows > 0 && backtestReady, drawCount, resultCount, frequencyRows, drawRows, backtestReady };
+          }
+          if (pageName === 'games') {
+            const gameCards = document.querySelectorAll('#game-grid [data-game]').length;
+            return { ok: gameCards > 0 && !/loading|unavailable/i.test(statusText), gameCards };
+          }
+          const certificateValues = ['cert-any-exact', 'cert-any-lower', 'cert-d4-exact', 'cert-overlap'].map(id => document.getElementById(id)?.textContent?.trim() || '');
+          const referenceReady = !document.querySelector('#benchmark-reference .skeleton-lines');
+          return { ok: certificateValues.every(value => value && !/loading|checking|^0{2}\.0/i.test(value)) && referenceReady, certificateValues, referenceReady };
+        })();
+
         return {
           title: document.title,
-          readyState: document.readyState,
           dataTheme: document.documentElement.getAttribute('data-theme'),
+          themePreference: document.documentElement.getAttribute('data-theme-preference'),
           innerWidth,
           scrollWidth: document.documentElement.scrollWidth,
           bodyScrollWidth: document.body.scrollWidth,
-          body: sample('body'),
-          html: sample('html'),
-          navbar: sample('.navbar'),
-          hero: sample('.hero'),
-          heroBox: sample('.hero .box'),
-          heroBoxTitle: sample('.hero .box .title'),
-          firstBox: sample('.box'),
-          firstSection: sample('.section'),
           overflow,
           skeletons,
           skeletonCount: skeletons.length,
-          navBurgerVisible: (() => {
-            const element = document.querySelector('.navbar-burger');
-            return element ? visible(element) : false;
-          })(),
+          lowContrast: lowContrast.slice(0, 30),
+          shadowedSurfaces,
+          menuItemCount: menuRects.length,
+          menuOverlap,
+          menuTooShort,
+          localBulma,
+          localLucide,
+          visibleLegacyText: bodyText.includes('legacy data') || bodyText.includes('legacy statistics'),
+          statusText,
+          loaded,
         };
-      });
+      }, { pageName, viewportName, theme });
 
       const filename = `browser-audit/${pageName}-${viewportName}-${theme}.png`;
       await page.screenshot({ path: filename, fullPage: true });
-      report.push({
-        page: pageName,
-        viewport: viewportName,
-        theme,
-        url,
-        navigationError,
-        consoleErrors,
-        requestFailures,
-        ...metrics,
-      });
+      report.push({ page: pageName, viewport: viewportName, theme, url, navigationError, consoleErrors, requestFailures, ...metrics });
       await context.close();
     }
   }
@@ -130,9 +198,18 @@ for (const row of report) {
   if (row.navigationError) failures.push(`${label}: navigation failed: ${row.navigationError}`);
   if (row.consoleErrors.length) failures.push(`${label}: ${row.consoleErrors.length} console error(s)`);
   if (row.requestFailures.length) failures.push(`${label}: ${row.requestFailures.length} request failure(s)`);
+  if (!row.localBulma) failures.push(`${label}: local Bulma stylesheet did not load`);
+  if (!row.localLucide) failures.push(`${label}: local Lucide runtime did not load`);
   if (row.skeletonCount) failures.push(`${label}: ${row.skeletonCount} visible skeleton(s) remain`);
   if (row.scrollWidth > row.innerWidth + 1) failures.push(`${label}: horizontal overflow ${row.scrollWidth}px > ${row.innerWidth}px`);
   if (row.dataTheme !== row.theme) failures.push(`${label}: theme mismatch (${row.dataTheme} != ${row.theme})`);
+  if (row.lowContrast.length) failures.push(`${label}: ${row.lowContrast.length} sampled text element(s) below 3:1 contrast`);
+  if (row.shadowedSurfaces.length) failures.push(`${label}: ${row.shadowedSurfaces.length} visible box/card surface(s) still have shadows`);
+  if (row.viewport === 'mobile' && row.menuItemCount === 0) failures.push(`${label}: mobile menu did not open`);
+  if (row.viewport === 'mobile' && row.menuOverlap) failures.push(`${label}: mobile navbar items overlap`);
+  if (row.viewport === 'mobile' && row.menuTooShort) failures.push(`${label}: mobile navbar items are too tightly packed`);
+  if (row.visibleLegacyText) failures.push(`${label}: legacy-data messaging is visible`);
+  if (!row.loaded.ok) failures.push(`${label}: page-specific content did not finish loading (${JSON.stringify(row.loaded)})`);
 }
 
 if (failures.length) {
@@ -140,5 +217,5 @@ if (failures.length) {
   failures.forEach(message => console.error(`- ${message}`));
   process.exitCode = 1;
 } else {
-  console.log(`UI browser audit passed: ${report.length} page/viewport/theme combinations.`);
+  console.log(`UI browser audit passed: ${report.length} page/viewport/theme combinations with contrast, data and mobile-menu checks.`);
 }

--- a/.github/scripts/prepare_site.sh
+++ b/.github/scripts/prepare_site.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+rm -rf _site
+mkdir -p _site/assets/vendor
+
+cp index.html games.html benchmark.html service-worker.js _site/
+cp -R assets/. _site/assets/
+cp node_modules/bulma/css/bulma.min.css _site/assets/vendor/bulma.min.css
+cp node_modules/lucide/dist/umd/lucide.js _site/assets/vendor/lucide.js
+: > _site/.nojekyll
+
+test -s _site/assets/vendor/bulma.min.css
+test -s _site/assets/vendor/lucide.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,26 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           cache: pip
       - name: Install dependencies
-        run: python -m pip install -r requirements-dev.txt
+        run: |
+          python -m pip install -r requirements-dev.txt
+          npm install --ignore-scripts --no-audit --no-fund
       - name: Ruff
         run: ruff check src tests
       - name: Compile
@@ -70,7 +79,7 @@ jobs:
           assert cash3['distinctOrderings'] == 3
           assert 333 < cash3['anyOrderOdds'] < 334
           PY
-      - name: Validate existing dataset and generated assets
+      - name: Validate existing dataset and regenerate canonical publication assets
         env:
           PYTHONPATH: src
         run: |
@@ -82,6 +91,9 @@ jobs:
 
           with open('assets/lotto_stats.json', encoding='utf-8') as handle:
               stats = json.load(handle)
+          assert stats['schemaVersion'] == 3
+          assert stats['dataset']['drawCount'] > 0
+          assert stats['draws']
           exact = stats['referenceCoverageSet']['exactAnyPrize']
           certificate = stats['referenceCoverageSet']['metrics']['probabilityCertificates']['anyPrize']
           assert exact['exact'] is True
@@ -90,6 +102,8 @@ jobs:
           assert exact['probability'] <= certificate['firstOrderUnionBound']
           print('REFERENCE_EXACT_ANY_PRIZE=' + json.dumps(exact, sort_keys=True))
           PY
+      - name: Build self-contained site payload
+        run: bash .github/scripts/prepare_site.sh
       - name: Validate certified objective benchmark
         env:
           PYTHONPATH: src
@@ -114,15 +128,9 @@ jobs:
           summary = {
               strategy: {
                   'anyPrizeRate': round(result['strategies'][strategy]['anyPrizeRate']['mean'], 6),
-                  'anyPrizeLowerBound': round(
-                      result['strategies'][strategy]['anyPrizeBonferroniLowerBound']['mean'], 6
-                  ),
-                  'division4Rate': round(
-                      result['strategies'][strategy]['division4OrBetterRate']['mean'], 6
-                  ),
-                  'division4GlobalOptimalRate': round(
-                      result['strategies'][strategy]['division4GloballyOptimal']['mean'], 4
-                  ),
+                  'anyPrizeLowerBound': round(result['strategies'][strategy]['anyPrizeBonferroniLowerBound']['mean'], 6),
+                  'division4Rate': round(result['strategies'][strategy]['division4OrBetterRate']['mean'], 6),
+                  'division4GlobalOptimalRate': round(result['strategies'][strategy]['division4GloballyOptimal']['mean'], 4),
               }
               for strategy in ('coverage', 'anyPrizeBound', 'division4Bound', 'random')
           }
@@ -134,9 +142,7 @@ jobs:
                       comparisons[name][metric] = {
                           'inferenceSuppressed': True,
                           'exactProbabilityDifference': values['exactProbabilityDifference'],
-                          'descriptiveSimulatedMeanDifference': round(
-                              values['descriptiveSimulatedMeanDifference'], 8
-                          ),
+                          'descriptiveSimulatedMeanDifference': round(values['descriptiveSimulatedMeanDifference'], 8),
                           'reason': values['reason'],
                       }
                       continue
@@ -180,15 +186,9 @@ jobs:
               assert metrics['exactAnyPrizeProbability']['min'] >= 0
           summary = {
               strategy: {
-                  'exactAnyPrize': round(
-                      result['strategies'][strategy]['exactAnyPrizeProbability']['mean'], 8
-                  ),
-                  'lowerBound': round(
-                      result['strategies'][strategy]['anyPrizeBonferroniLowerBound']['mean'], 8
-                  ),
-                  'meanBoundGap': round(
-                      result['strategies'][strategy]['bonferroniGap']['mean'], 8
-                  ),
+                  'exactAnyPrize': round(result['strategies'][strategy]['exactAnyPrizeProbability']['mean'], 8),
+                  'lowerBound': round(result['strategies'][strategy]['anyPrizeBonferroniLowerBound']['mean'], 8),
+                  'meanBoundGap': round(result['strategies'][strategy]['bonferroniGap']['mean'], 8),
               }
               for strategy in ('coverage', 'anyPrizeBound', 'division4Bound', 'random')
           }
@@ -215,44 +215,43 @@ jobs:
           node --check assets/certificates.js
           node --check assets/games.js
           node --check service-worker.js
-      - name: Validate Bulma-only static site
+          node --check .github/scripts/browser_audit.mjs
+      - name: Validate self-contained Bulma-only site
         run: |
-          test -f index.html
-          test -f benchmark.html
-          test -f games.html
-          test -f assets/ui.js
-          test -f assets/app.js
-          test -f assets/benchmark.js
-          test -f assets/certificates.js
-          test -f assets/games.js
-          test -f assets/lotto_stats.json
-          test -f assets/data_provenance.json
-          test -f assets/site.webmanifest
-          test -f service-worker.js
-          test ! -f assets/app.css
-          test ! -f assets/benchmark.css
-          test ! -f assets/games.css
-          grep -q 'bulma@1.0.4/css/bulma.min.css' index.html
-          grep -q 'bulma@1.0.4/css/bulma.min.css' benchmark.html
-          grep -q 'bulma@1.0.4/css/bulma.min.css' games.html
-          grep -q 'lucide@1.33.0/dist/umd/lucide.js' index.html
-          grep -q 'lucide@1.33.0/dist/umd/lucide.js' benchmark.html
-          grep -q 'lucide@1.33.0/dist/umd/lucide.js' games.html
-          grep -q 'assets/ui.js' index.html
-          grep -q 'assets/app.js' index.html
-          grep -q 'assets/benchmark.js' benchmark.html
-          grep -q 'assets/certificates.js' benchmark.html
-          grep -q 'id="certificates"' benchmark.html
-          grep -q 'id="cert-any-exact"' benchmark.html
-          grep -q 'exactAnyPrize' assets/certificates.js
-          grep -q 'assets/games.js' games.html
-          grep -q 'id="game-grid"' games.html
-          grep -q 'id="keno-spot"' games.html
-          grep -q 'games.html' assets/site.webmanifest
-          grep -q 'assets/ui.js' service-worker.js
-          grep -q 'assets/games.js' service-worker.js
-          grep -q 'assets/certificates.js' service-worker.js
-          grep -q 'benchmark.html' service-worker.js
-          grep -q 'games.html' service-worker.js
-          grep -q 'service-worker.js' assets/app.js
-          ! grep -R -n 'style=' index.html games.html benchmark.html assets/ui.js assets/app.js assets/games.js assets/benchmark.js assets/certificates.js
+          test -f _site/index.html
+          test -f _site/benchmark.html
+          test -f _site/games.html
+          test -f _site/assets/ui.js
+          test -f _site/assets/app.js
+          test -f _site/assets/benchmark.js
+          test -f _site/assets/certificates.js
+          test -f _site/assets/games.js
+          test -s _site/assets/vendor/bulma.min.css
+          test -s _site/assets/vendor/lucide.js
+          test ! -f _site/assets/app.css
+          test ! -f _site/assets/benchmark.css
+          test ! -f _site/assets/games.css
+          grep -q 'assets/vendor/bulma.min.css' _site/index.html
+          grep -q 'assets/vendor/bulma.min.css' _site/benchmark.html
+          grep -q 'assets/vendor/bulma.min.css' _site/games.html
+          grep -q 'assets/vendor/lucide.js' _site/index.html
+          grep -q 'assets/vendor/lucide.js' _site/benchmark.html
+          grep -q 'assets/vendor/lucide.js' _site/games.html
+          ! grep -q 'cdn.jsdelivr.net' _site/index.html
+          ! grep -q 'unpkg.com' _site/index.html
+          grep -q 'assets/ui.js' _site/index.html
+          grep -q 'assets/app.js' _site/index.html
+          grep -q 'assets/benchmark.js' _site/benchmark.html
+          grep -q 'assets/certificates.js' _site/benchmark.html
+          grep -q 'id="certificates"' _site/benchmark.html
+          grep -q 'id="cert-any-exact"' _site/benchmark.html
+          grep -q 'exactAnyPrize' _site/assets/certificates.js
+          grep -q 'assets/games.js' _site/games.html
+          grep -q 'id="game-grid"' _site/games.html
+          grep -q 'id="keno-spot"' _site/games.html
+          grep -q 'games.html' _site/assets/site.webmanifest
+          grep -q 'assets/vendor/bulma.min.css' _site/service-worker.js
+          grep -q 'assets/vendor/lucide.js' _site/service-worker.js
+          ! grep -q 'cdn.jsdelivr.net' _site/service-worker.js
+          ! grep -q 'unpkg.com' _site/service-worker.js
+          ! grep -R -n 'style=' _site/index.html _site/games.html _site/benchmark.html _site/assets/ui.js _site/assets/app.js _site/assets/games.js _site/assets/benchmark.js _site/assets/certificates.js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,10 +9,15 @@ on:
       - 'games.html'
       - 'service-worker.js'
       - 'assets/**'
+      - 'src/lotto_lab/**'
+      - 'winning_numbers.csv'
+      - 'supplementary_numbers.csv'
+      - 'requirements.txt'
+      - 'package.json'
       - 'README.md'
       - 'ROADMAP.md'
       - 'GITHUB_PAGES.md'
-      - '.nojekyll'
+      - '.github/scripts/prepare_site.sh'
       - '.github/workflows/deploy.yml'
   workflow_dispatch:
 
@@ -31,43 +36,71 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-      - name: Validate static site payload
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: npm
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: Install pinned site and runtime dependencies
         run: |
-          test -f index.html
-          test -f benchmark.html
-          test -f games.html
-          test -f service-worker.js
-          test -f assets/ui.js
-          test -f assets/app.js
-          test -f assets/benchmark.js
-          test -f assets/certificates.js
-          test -f assets/games.js
-          test -f assets/game_catalog.json
-          test -f assets/lotto_stats.json
-          test ! -f assets/app.css
-          test ! -f assets/games.css
-          test ! -f assets/benchmark.css
-          grep -q 'bulma@1.0.4/css/bulma.min.css' index.html
-          grep -q 'bulma@1.0.4/css/bulma.min.css' games.html
-          grep -q 'bulma@1.0.4/css/bulma.min.css' benchmark.html
-          grep -q 'lucide@1.33.0/dist/umd/lucide.js' index.html
-          grep -q 'lucide@1.33.0/dist/umd/lucide.js' games.html
-          grep -q 'lucide@1.33.0/dist/umd/lucide.js' benchmark.html
-          ! grep -R -n 'style=' index.html games.html benchmark.html assets/ui.js assets/app.js assets/games.js assets/benchmark.js assets/certificates.js
-          node --check assets/ui.js
-          node --check assets/app.js
-          node --check assets/benchmark.js
-          node --check assets/certificates.js
-          node --check assets/games.js
-          node --check service-worker.js
-          python -m json.tool assets/game_catalog.json >/dev/null
-          python -m json.tool assets/lotto_stats.json >/dev/null
+          npm install --ignore-scripts --no-audit --no-fund
+          python -m pip install -r requirements.txt
+      - name: Regenerate canonical publication data
+        env:
+          PYTHONPATH: src
+        run: python -m lotto_lab stats
+      - name: Build self-contained site payload
+        run: bash .github/scripts/prepare_site.sh
+      - name: Validate publication payload
+        run: |
+          test -f _site/index.html
+          test -f _site/benchmark.html
+          test -f _site/games.html
+          test -f _site/service-worker.js
+          test -f _site/assets/ui.js
+          test -f _site/assets/app.js
+          test -f _site/assets/benchmark.js
+          test -f _site/assets/certificates.js
+          test -f _site/assets/games.js
+          test -s _site/assets/vendor/bulma.min.css
+          test -s _site/assets/vendor/lucide.js
+          test ! -f _site/assets/app.css
+          test ! -f _site/assets/games.css
+          test ! -f _site/assets/benchmark.css
+          grep -q 'assets/vendor/bulma.min.css' _site/index.html
+          grep -q 'assets/vendor/bulma.min.css' _site/games.html
+          grep -q 'assets/vendor/bulma.min.css' _site/benchmark.html
+          grep -q 'assets/vendor/lucide.js' _site/index.html
+          grep -q 'assets/vendor/lucide.js' _site/games.html
+          grep -q 'assets/vendor/lucide.js' _site/benchmark.html
+          ! grep -R -n 'style=' _site/index.html _site/games.html _site/benchmark.html _site/assets/ui.js _site/assets/app.js _site/assets/games.js _site/assets/benchmark.js _site/assets/certificates.js
+          node --check _site/assets/ui.js
+          node --check _site/assets/app.js
+          node --check _site/assets/benchmark.js
+          node --check _site/assets/certificates.js
+          node --check _site/assets/games.js
+          node --check _site/service-worker.js
+          python -m json.tool _site/assets/game_catalog.json >/dev/null
+          python -m json.tool _site/assets/lotto_stats.json >/dev/null
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          stats = json.loads(Path('_site/assets/lotto_stats.json').read_text(encoding='utf-8'))
+          assert stats.get('schemaVersion') == 3, 'Pages must publish canonical schemaVersion 3 stats'
+          assert stats.get('dataset', {}).get('drawCount', 0) > 0
+          assert stats.get('draws'), 'Pages must publish draw history, not a legacy summary-only asset'
+          PY
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:
-          path: '.'
+          path: '_site'
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,6 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
-          cache: npm
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'

--- a/.github/workflows/ui-browser.yml
+++ b/.github/workflows/ui-browser.yml
@@ -12,6 +12,8 @@ on:
       - 'assets/benchmark.js'
       - 'assets/certificates.js'
       - 'service-worker.js'
+      - 'package.json'
+      - '.github/scripts/prepare_site.sh'
       - '.github/scripts/browser_audit.mjs'
       - '.github/workflows/ui-browser.yml'
 
@@ -25,18 +27,31 @@ concurrency:
 jobs:
   audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
           node-version: '22'
-      - name: Install Chromium audit runtime
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+      - name: Install pinned site, runtime and Chromium dependencies
         run: |
-          npm install --no-save playwright@1.55.0
+          npm install --ignore-scripts --no-audit --no-fund
+          npm install --no-save --ignore-scripts --no-audit --no-fund playwright@1.55.0
+          python -m pip install -r requirements.txt
           npx playwright install --with-deps chromium
-      - name: Start static site
+      - name: Regenerate canonical publication data
+        env:
+          PYTHONPATH: src
+        run: python -m lotto_lab stats
+      - name: Build self-contained site payload
+        run: bash .github/scripts/prepare_site.sh
+      - name: Start built static site
         run: |
+          cd _site
           python3 -m http.server 8000 --bind 127.0.0.1 >/tmp/lotto-http.log 2>&1 &
           for i in {1..20}; do
             if curl -fsS http://127.0.0.1:8000/ >/dev/null; then exit 0; fi

--- a/assets/games.js
+++ b/assets/games.js
@@ -4,11 +4,7 @@
 
   const nf = new Intl.NumberFormat('en-AU', { maximumFractionDigits: 2 });
   const pct = new Intl.NumberFormat('en-AU', { style: 'percent', maximumFractionDigits: 8 });
-  const money = new Intl.NumberFormat('en-AU', {
-    style: 'currency',
-    currency: 'AUD',
-    maximumFractionDigits: 0,
-  });
+  const money = new Intl.NumberFormat('en-AU', { style: 'currency', currency: 'AUD', maximumFractionDigits: 0 });
   const mechanicNames = {
     'one-pool': 'Combination draw',
     'two-pool': 'Two-pool draw',
@@ -49,17 +45,13 @@
   function snapshotRows(snapshot) {
     if (!snapshot) return '';
     const rows = [];
-    if (snapshot.ticketPriceFrom != null) {
-      rows.push(`<tr><th>Ticket from</th><td>${escapeHtml(money.format(snapshot.ticketPriceFrom))}</td></tr>`);
-    }
+    if (snapshot.ticketPriceFrom != null) rows.push(`<tr><th>Ticket from</th><td>${escapeHtml(money.format(snapshot.ticketPriceFrom))}</td></tr>`);
     if (snapshot.minimumPossibleEntries != null && snapshot.maximumEntries != null) {
       rows.push(`<tr><th>Entry range</th><td>${nf.format(snapshot.minimumPossibleEntries)}–${nf.format(snapshot.maximumEntries)}</td></tr>`);
     } else if (snapshot.maximumEntries != null) {
       rows.push(`<tr><th>Capacity</th><td>Up to ${nf.format(snapshot.maximumEntries)}</td></tr>`);
     }
-    if (snapshot.drawDate && snapshot.drawDate !== 'varies') {
-      rows.push(`<tr><th>Snapshot draw</th><td>${escapeHtml(snapshot.drawDate)}</td></tr>`);
-    }
+    if (snapshot.drawDate && snapshot.drawDate !== 'varies') rows.push(`<tr><th>Snapshot draw</th><td>${escapeHtml(snapshot.drawDate)}</td></tr>`);
     return rows.join('');
   }
 
@@ -80,9 +72,7 @@
         const bOdds = b.computedTopOdds ?? b.officialTopOdds ?? Infinity;
         return aOdds - bOdds;
       });
-    } else {
-      filtered = [...filtered].sort((a, b) => a.name.localeCompare(b.name));
-    }
+    } else filtered = [...filtered].sort((a, b) => a.name.localeCompare(b.name));
 
     document.getElementById('game-count').textContent = `${filtered.length} option${filtered.length === 1 ? '' : 's'}`;
     document.getElementById('game-grid').innerHTML = filtered.map(game => {
@@ -94,19 +84,19 @@
       const sourceUrl = snapshot?.sourceUrl || game.sourceUrl;
       const icon = mechanicIcons[game.mechanic] || 'circle-help';
       return `
-        <div class="column is-half" data-game="${escapeHtml(game.slug)}">
-          <article class="card">
+        <div class="column is-half px-2" data-game="${escapeHtml(game.slug)}">
+          <article class="card is-shadowless">
             <div class="card-content">
               <div class="media">
                 <div class="media-left"><span class="icon is-large"><i data-lucide="${icon}"></i></span></div>
                 <div class="media-content"><p class="title is-5">${escapeHtml(game.name)}</p><p class="subtitle is-7">${escapeHtml(game.operator)}</p></div>
-                <div class="media-right"><span class="tag ${isComputed ? 'is-success' : 'is-warning'} is-light">${isComputed ? 'Computed' : 'Variable / reported'}</span></div>
+                <div class="media-right"><span class="tag ${isComputed ? 'is-success' : 'is-warning'}">${isComputed ? 'Computed' : 'Variable / reported'}</span></div>
               </div>
               <div class="content">
                 <p>${escapeHtml(game.description)}</p>
-                <div class="columns is-mobile">
-                  <div class="column"><p class="heading">Top / Division 1</p><p class="title is-6">${formatOdds(topOdds)}</p></div>
-                  <div class="column"><p class="heading">Any prize</p><p class="title is-6">${formatOdds(anyOdds)}</p></div>
+                <div class="columns is-mobile is-multiline mx-0">
+                  <div class="column is-half px-2"><p class="heading">Top / Division 1</p><p class="title is-6">${formatOdds(topOdds)}</p></div>
+                  <div class="column is-half px-2"><p class="heading">Any prize</p><p class="title is-6">${formatOdds(anyOdds)}</p></div>
                 </div>
                 <div class="table-container"><table class="table is-fullwidth is-narrow"><tbody>
                   <tr><th>Mechanic</th><td>${escapeHtml(mechanicNames[game.mechanic] || game.mechanic)}</td></tr>
@@ -115,7 +105,7 @@
                   ${snapshotRows(snapshot)}
                 </tbody></table></div>
                 ${note ? `<div class="notification">${escapeHtml(note)}</div>` : ''}
-                ${sourceUrl ? `<a class="button is-small is-link is-light" href="${escapeHtml(sourceUrl)}" target="_blank" rel="noreferrer"><span class="icon"><i data-lucide="external-link"></i></span><span>Official source</span></a>` : ''}
+                ${sourceUrl ? `<a class="button is-small is-link is-outlined" href="${escapeHtml(sourceUrl)}" target="_blank" rel="noreferrer"><span class="icon"><i data-lucide="external-link"></i></span><span>Official source</span></a>` : ''}
               </div>
             </div>
           </article>
@@ -163,11 +153,9 @@
 
   function populateFilters() {
     const operatorSelect = document.getElementById('game-operator');
-    [...new Set(games.map(game => game.operator))].sort()
-      .forEach(operator => operatorSelect.add(new Option(operator, operator)));
+    [...new Set(games.map(game => game.operator))].sort().forEach(operator => operatorSelect.add(new Option(operator, operator)));
     const mechanicSelect = document.getElementById('game-mechanic');
-    [...new Set(games.map(game => game.mechanic))].sort()
-      .forEach(mechanic => mechanicSelect.add(new Option(mechanicNames[mechanic] || mechanic, mechanic)));
+    [...new Set(games.map(game => game.mechanic))].sort().forEach(mechanic => mechanicSelect.add(new Option(mechanicNames[mechanic] || mechanic, mechanic)));
   }
 
   async function loadCatalog() {
@@ -195,9 +183,7 @@
     }
   }
 
-  ['game-operator', 'game-mechanic', 'game-jurisdiction', 'game-sort'].forEach(id =>
-    document.getElementById(id).addEventListener('change', renderGames)
-  );
+  ['game-operator', 'game-mechanic', 'game-jurisdiction', 'game-sort'].forEach(id => document.getElementById(id).addEventListener('change', renderGames));
   document.getElementById('sfl-draws').addEventListener('input', renderSetForLife);
   document.getElementById('keno-spot').addEventListener('input', renderKeno);
   document.getElementById('cash3-digits').addEventListener('input', renderCash3);

--- a/assets/ui.js
+++ b/assets/ui.js
@@ -1,6 +1,5 @@
 (() => {
   const THEME_KEY = 'lotto-theme';
-  const RELOAD_KEY = 'lotto-sw-reloaded';
   const themes = ['system', 'light', 'dark'];
   const media = window.matchMedia('(prefers-color-scheme: dark)');
   let resolvedTheme = 'light';
@@ -12,19 +11,39 @@
 
   function harmonizeTheme(root = document) {
     const scope = root instanceof Element ? root : document;
-    const candidates = [];
+    const lightVariants = [];
+    const outlinedButtons = [];
     const surfaces = [];
+    const selectedNavItems = [];
+
     if (root instanceof Element) {
-      if (root.classList.contains('is-light') || root.dataset.bulmaLightVariant === 'true') candidates.push(root);
+      if (root.classList.contains('is-light') || root.dataset.bulmaLightVariant === 'true') lightVariants.push(root);
+      if (root.classList.contains('is-outlined') || root.dataset.bulmaOutlinedVariant === 'true') outlinedButtons.push(root);
       if (root.classList.contains('box') || root.classList.contains('card')) surfaces.push(root);
+      if (root.classList.contains('navbar-item') && root.classList.contains('is-selected')) selectedNavItems.push(root);
     }
-    scope.querySelectorAll?.('.is-light, [data-bulma-light-variant="true"]').forEach(element => candidates.push(element));
+
+    scope.querySelectorAll?.('.is-light, [data-bulma-light-variant="true"]').forEach(element => lightVariants.push(element));
+    scope.querySelectorAll?.('.button.is-outlined, .button[data-bulma-outlined-variant="true"]').forEach(element => outlinedButtons.push(element));
     scope.querySelectorAll?.('.box, .card').forEach(element => surfaces.push(element));
-    [...new Set(candidates)].forEach(element => {
+    scope.querySelectorAll?.('.navbar-item.is-selected').forEach(element => selectedNavItems.push(element));
+
+    [...new Set(lightVariants)].forEach(element => {
       element.dataset.bulmaLightVariant = 'true';
       element.classList.toggle('is-light', resolvedTheme !== 'dark');
     });
+
+    [...new Set(outlinedButtons)].forEach(element => {
+      element.dataset.bulmaOutlinedVariant = 'true';
+      element.classList.toggle('is-outlined', resolvedTheme !== 'dark');
+    });
+
     [...new Set(surfaces)].forEach(element => element.classList.add('is-shadowless'));
+
+    [...new Set(selectedNavItems)].forEach(element => {
+      element.classList.remove('is-selected');
+      element.classList.add('has-text-weight-semibold');
+    });
   }
 
   function applyTheme(theme) {
@@ -86,11 +105,6 @@
 
   function setupServiceWorker() {
     if (!('serviceWorker' in navigator)) return;
-    navigator.serviceWorker.addEventListener('controllerchange', () => {
-      if (sessionStorage.getItem(RELOAD_KEY) === 'true') return;
-      sessionStorage.setItem(RELOAD_KEY, 'true');
-      location.reload();
-    });
     window.addEventListener('load', async () => {
       try {
         const registration = await navigator.serviceWorker.register('./service-worker.js');

--- a/assets/ui.js
+++ b/assets/ui.js
@@ -1,45 +1,66 @@
 (() => {
   const THEME_KEY = 'lotto-theme';
+  const RELOAD_KEY = 'lotto-sw-reloaded';
   const themes = ['system', 'light', 'dark'];
+  const media = window.matchMedia('(prefers-color-scheme: dark)');
+  let resolvedTheme = 'light';
 
   function refreshIcons() {
-    if (!window.lucide?.createIcons) return;
-    window.lucide.createIcons();
+    harmonizeTheme(document);
+    if (window.lucide?.createIcons) window.lucide.createIcons();
+  }
+
+  function harmonizeTheme(root = document) {
+    const scope = root instanceof Element ? root : document;
+    const candidates = [];
+    if (root instanceof Element && (root.classList.contains('is-light') || root.dataset.bulmaLightVariant === 'true')) {
+      candidates.push(root);
+    }
+    scope.querySelectorAll?.('.is-light, [data-bulma-light-variant="true"]').forEach(element => candidates.push(element));
+    [...new Set(candidates)].forEach(element => {
+      element.dataset.bulmaLightVariant = 'true';
+      element.classList.toggle('is-light', resolvedTheme !== 'dark');
+    });
   }
 
   function applyTheme(theme) {
-    const value = themes.includes(theme) ? theme : 'system';
-    if (value === 'system') document.documentElement.removeAttribute('data-theme');
-    else document.documentElement.setAttribute('data-theme', value);
-    localStorage.setItem(THEME_KEY, value);
+    const preference = themes.includes(theme) ? theme : 'system';
+    resolvedTheme = preference === 'system' ? (media.matches ? 'dark' : 'light') : preference;
+    document.documentElement.setAttribute('data-theme', resolvedTheme);
+    document.documentElement.setAttribute('data-theme-preference', preference);
+    localStorage.setItem(THEME_KEY, preference);
 
-    const resolved = value === 'system'
-      ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-      : value;
     const themeMeta = document.querySelector('meta[name="theme-color"]');
-    if (themeMeta) themeMeta.content = resolved === 'dark' ? '#14161a' : '#ffffff';
+    if (themeMeta) themeMeta.content = resolvedTheme === 'dark' ? '#14161a' : '#ffffff';
 
     const button = document.getElementById('theme-toggle');
     const icon = document.getElementById('theme-icon');
     if (button) {
-      button.setAttribute('aria-label', `Theme: ${value}. Activate to change theme.`);
-      button.title = `Theme: ${value}`;
+      const label = preference === 'system' ? `System (${resolvedTheme})` : preference[0].toUpperCase() + preference.slice(1);
+      button.setAttribute('aria-label', `Theme: ${label}. Activate to change theme.`);
+      button.title = `Theme: ${label}`;
     }
-    if (icon) {
-      icon.setAttribute('data-lucide', value === 'dark' ? 'moon' : value === 'light' ? 'sun' : 'monitor');
-    }
-    refreshIcons();
+    if (icon) icon.setAttribute('data-lucide', preference === 'dark' ? 'moon' : preference === 'light' ? 'sun' : 'monitor');
+    harmonizeTheme(document);
+    if (window.lucide?.createIcons) window.lucide.createIcons();
   }
 
   function setupTheme() {
     applyTheme(localStorage.getItem(THEME_KEY) || 'system');
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    media.addEventListener('change', () => {
       if ((localStorage.getItem(THEME_KEY) || 'system') === 'system') applyTheme('system');
     });
     document.getElementById('theme-toggle')?.addEventListener('click', () => {
       const current = localStorage.getItem(THEME_KEY) || 'system';
       applyTheme(themes[(themes.indexOf(current) + 1) % themes.length]);
     });
+
+    const observer = new MutationObserver(records => {
+      records.forEach(record => record.addedNodes.forEach(node => {
+        if (node instanceof Element) harmonizeTheme(node);
+      }));
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
   }
 
   function setupNavbars() {
@@ -59,12 +80,31 @@
     root.querySelectorAll('.skeleton-block, .skeleton-lines').forEach(element => element.remove());
   }
 
+  function setupServiceWorker() {
+    if (!('serviceWorker' in navigator)) return;
+    navigator.serviceWorker.addEventListener('controllerchange', () => {
+      if (sessionStorage.getItem(RELOAD_KEY) === 'true') return;
+      sessionStorage.setItem(RELOAD_KEY, 'true');
+      location.reload();
+    });
+    window.addEventListener('load', async () => {
+      try {
+        const registration = await navigator.serviceWorker.register('./service-worker.js');
+        await registration.update();
+      } catch (error) {
+        console.warn('Service worker registration failed', error);
+      }
+    });
+  }
+
   window.refreshIcons = refreshIcons;
   window.clearSkeletons = clearSkeletons;
+  window.applyLotteryTheme = applyTheme;
 
   function setup() {
     setupTheme();
     setupNavbars();
+    setupServiceWorker();
     refreshIcons();
   }
 

--- a/assets/ui.js
+++ b/assets/ui.js
@@ -13,14 +13,18 @@
   function harmonizeTheme(root = document) {
     const scope = root instanceof Element ? root : document;
     const candidates = [];
-    if (root instanceof Element && (root.classList.contains('is-light') || root.dataset.bulmaLightVariant === 'true')) {
-      candidates.push(root);
+    const surfaces = [];
+    if (root instanceof Element) {
+      if (root.classList.contains('is-light') || root.dataset.bulmaLightVariant === 'true') candidates.push(root);
+      if (root.classList.contains('box') || root.classList.contains('card')) surfaces.push(root);
     }
     scope.querySelectorAll?.('.is-light, [data-bulma-light-variant="true"]').forEach(element => candidates.push(element));
+    scope.querySelectorAll?.('.box, .card').forEach(element => surfaces.push(element));
     [...new Set(candidates)].forEach(element => {
       element.dataset.bulmaLightVariant = 'true';
       element.classList.toggle('is-light', resolvedTheme !== 'dark');
     });
+    [...new Set(surfaces)].forEach(element => element.classList.add('is-shadowless'));
   }
 
   function applyTheme(theme) {

--- a/benchmark.html
+++ b/benchmark.html
@@ -9,83 +9,109 @@
   <title>Benchmarks · Lottery Lab</title>
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="manifest" href="assets/site.webmanifest">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
-  <script defer src="https://unpkg.com/lucide@1.33.0/dist/umd/lucide.js"></script>
+  <link rel="stylesheet" href="assets/vendor/bulma.min.css">
+  <script defer src="assets/vendor/lucide.js"></script>
   <script defer src="assets/ui.js"></script>
   <script defer src="assets/benchmark.js"></script>
   <script defer src="assets/certificates.js"></script>
 </head>
 <body>
-  <nav class="navbar is-spaced has-shadow" role="navigation" aria-label="Primary navigation">
+  <nav class="navbar is-spaced" role="navigation" aria-label="Primary navigation">
     <div class="navbar-brand">
-      <a class="navbar-item" href="benchmark.html"><strong>Lottery Lab</strong>&nbsp;<span class="tag is-info is-light">Benchmarks</span></a>
+      <a class="navbar-item px-3" href="benchmark.html"><strong>Lottery Lab</strong>&nbsp;<span class="tag is-info">Benchmarks</span></a>
       <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="benchmark-navbar"><span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span></a>
     </div>
-    <div id="benchmark-navbar" class="navbar-menu">
+    <div id="benchmark-navbar" class="navbar-menu p-2">
       <div class="navbar-start">
-        <a class="navbar-item" href="index.html"><span class="icon"><i data-lucide="ticket"></i></span><span>Saturday</span></a>
-        <a class="navbar-item" href="games.html"><span class="icon"><i data-lucide="grid-2x2"></i></span><span>Games &amp; odds</span></a>
-        <a class="navbar-item is-selected" href="benchmark.html" aria-current="page"><span class="icon"><i data-lucide="chart-no-axes-combined"></i></span><span>Benchmarks</span></a>
-        <a class="navbar-item" href="#certificates"><span class="icon"><i data-lucide="badge-check"></i></span><span>Exact results</span></a>
+        <a class="navbar-item mx-1" href="index.html"><span class="icon"><i data-lucide="ticket"></i></span><span>Saturday</span></a>
+        <a class="navbar-item mx-1" href="games.html"><span class="icon"><i data-lucide="grid-2x2"></i></span><span>Games &amp; odds</span></a>
+        <a class="navbar-item mx-1 is-selected" href="benchmark.html" aria-current="page"><span class="icon"><i data-lucide="chart-no-axes-combined"></i></span><span>Benchmarks</span></a>
+        <a class="navbar-item mx-1" href="#certificates"><span class="icon"><i data-lucide="badge-check"></i></span><span>Exact results</span></a>
       </div>
-      <div class="navbar-end"><div class="navbar-item"><button id="theme-toggle" class="button is-light" type="button" aria-label="Change theme"><span class="icon"><i id="theme-icon" data-lucide="monitor"></i></span><span>Theme</span></button></div></div>
+      <div class="navbar-end"><div class="navbar-item mx-1"><button id="theme-toggle" class="button is-fullwidth" type="button" aria-label="Change theme"><span class="icon"><i id="theme-icon" data-lucide="monitor"></i></span><span>Theme</span></button></div></div>
     </div>
   </nav>
 
   <main>
     <section class="hero">
-      <div class="hero-body py-5"><div class="container"><div class="columns is-vcentered mx-0">
-        <div class="column is-three-fifths"><span class="tag is-info is-light mb-4">Saturday Lotto portfolio benchmarks</span><h1 class="title is-2">Exact results before simulations</h1><p class="subtitle is-5">Exact portfolio unions, certified bounds and multi-seed comparisons. Simulation remains only where the project has not solved the same question exactly.</p><div class="buttons"><a class="button is-info is-medium" href="#certificates"><span class="icon"><i data-lucide="badge-check"></i></span><span>Exact results</span></a><a class="button is-light is-medium" href="#evidence"><span class="icon"><i data-lucide="flask-conical"></i></span><span>Benchmark evidence</span></a></div></div>
-        <div class="column"><div class="box"><span class="tag is-success is-light mb-3">Invariant</span><h2 class="title is-4">Same number of distinct games</h2><p class="title is-3">Same Division 1 odds</p><div class="content"><p><strong>Coverage:</strong> n / 8,145,060</p><p><strong>QuickPick:</strong> n / 8,145,060</p><p><strong>Can differ:</strong> lower-tier overlap</p></div><div class="notification is-info is-light">The benchmark measures portfolio structure. It does not predict the next winning numbers.</div></div></div>
-      </div></div></div>
+      <div class="hero-body py-5">
+        <div class="container">
+          <div class="columns is-vcentered mx-0">
+            <div class="column is-three-fifths px-3">
+              <span class="tag is-info mb-4">Saturday Lotto portfolio benchmarks</span>
+              <h1 class="title is-2">Exact results before simulations</h1>
+              <p class="subtitle is-5">Exact portfolio unions, certified bounds and multi-seed comparisons. Simulation remains only where the project has not solved the same question exactly.</p>
+              <div class="buttons is-flex-wrap-wrap"><a class="button is-info is-medium" href="#certificates"><span class="icon"><i data-lucide="badge-check"></i></span><span>Exact results</span></a><a class="button is-medium is-outlined" href="#evidence"><span class="icon"><i data-lucide="flask-conical"></i></span><span>Benchmark evidence</span></a></div>
+            </div>
+            <div class="column px-3">
+              <div class="box is-shadowless">
+                <span class="tag is-success mb-3">Invariant</span>
+                <h2 class="title is-4">Same number of distinct games</h2>
+                <p class="title is-3">Same Division 1 odds</p>
+                <div class="content"><p><strong>Coverage:</strong> n / 8,145,060</p><p><strong>QuickPick:</strong> n / 8,145,060</p><p><strong>Can differ:</strong> lower-tier overlap</p></div>
+                <div class="notification mb-0">The benchmark measures portfolio structure. It does not predict the next winning numbers.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
 
-    <section class="section py-5"><div class="container"><article class="message is-warning"><div class="message-header"><p><span class="icon"><i data-lucide="scale"></i></span> Evidence order</p></div><div class="message-body"><strong>When exact combinatorics and simulation answer the same question, use the exact result.</strong> Pair, triple and quadruple coverage are exact structural measures; simulation remains for unresolved exploratory outcomes.</div></article></div></section>
+    <section class="section py-5"><div class="container"><article class="message"><div class="message-header"><p><span class="icon"><i data-lucide="scale"></i></span> Evidence order</p></div><div class="message-body"><strong>When exact combinatorics and simulation answer the same question, use the exact result.</strong> Pair, triple and quadruple coverage are exact structural measures; simulation remains for unresolved exploratory outcomes.</div></article></div></section>
 
-    <section class="section py-5" id="certificates"><div class="container">
-      <div class="mb-5"><span class="tag is-success is-light">Exact results</span><h2 class="title is-3 mt-3">Portfolio probability without simulation noise</h2><p class="subtitle is-5">The reference Coverage portfolio has exact any-prize probability from complement dynamic programming. Division 4-or-better is exact when its ticket events are pairwise disjoint.</p></div>
-      <div id="certificates-grid" class="columns is-multiline">
-        <div class="column is-one-quarter-desktop is-half-tablet"><div class="box"><div class="level is-mobile"><div class="level-left"><p class="heading">Exact any-prize probability</p></div><div class="level-right"><span class="tag is-success is-light">Exact</span></div></div><p class="title is-4 is-skeleton" id="cert-any-exact">00.0000%</p><p class="help" id="cert-any-exact-status">Loading exact count…</p></div></div>
-        <div class="column is-one-quarter-desktop is-half-tablet"><div class="box"><p class="heading">Certified lower bound</p><p class="title is-4 is-skeleton" id="cert-any-lower">00.0000%</p><p class="help" id="cert-any-upper">Loading bound…</p></div></div>
-        <div class="column is-one-quarter-desktop is-half-tablet"><div class="box"><div class="level is-mobile"><div class="level-left"><p class="heading">Division 4+ probability</p></div><div class="level-right"><span class="tag is-skeleton" id="cert-d4-badge">Checking</span></div></div><p class="title is-4 is-skeleton" id="cert-d4-exact">00.0000%</p><p class="help" id="cert-d4-status">Checking certificate…</p></div></div>
-        <div class="column is-one-quarter-desktop is-half-tablet"><div class="box"><p class="heading">Maximum ticket overlap</p><p class="title is-4 is-skeleton" id="cert-overlap">0</p><p class="help">≤1 makes ≥4-main events mutually exclusive in pairs.</p></div></div>
-      </div>
-      <div class="columns">
-        <div class="column"><article class="message is-success"><div class="message-header"><p><span class="icon"><i data-lucide="binary"></i></span> Exact any-prize algorithm</p></div><div class="message-body">Count six-ball draws where every ticket stays below three matches, then take the complement. States are integer counts; no draw simulation is needed.</div></article></div>
-        <div class="column"><article class="message is-info"><div class="message-header"><p><span class="icon"><i data-lucide="shield-check"></i></span> Division 4 certificate</p></div><div class="message-body">Pairwise ticket overlap of at most one number makes ≥4-main events pairwise disjoint, reaching the sum-of-marginals upper bound.</div></article></div>
-      </div>
-    </div></section>
-
-    <section class="section py-5" id="evidence"><div class="container">
-      <div class="mb-5"><span class="tag is-info is-light">Comparisons</span><h2 class="title is-3 mt-3">Coverage against alternative portfolio populations</h2><p class="subtitle is-5">The repository benchmark compares independent portfolio seeds. Local browser runs are explicitly exploratory.</p></div>
-      <article class="message is-info"><div class="message-header"><p><span class="icon"><i data-lucide="info"></i></span> Interpretation</p></div><div class="message-body">Probability-of-superiority is a benchmark statistic. It is not the probability that a strategy wins the lottery.</div></article>
-
-      <div id="portfolio-benchmark" class="box">
-        <div class="level"><div class="level-left"><div><span class="tag is-info is-light">Multi-seed benchmark</span><h3 class="title is-4 mt-3">Coverage portfolios vs QuickPick distributions</h3><p class="subtitle is-6">Independent portfolio seeds are evaluated on the same simulated draws.</p></div></div><div class="level-right"><span class="tag">Distribution test</span></div></div>
-        <div id="benchmark-reference" aria-live="polite"><div class="skeleton-lines"><div></div><div></div><div></div><div></div></div></div>
-        <hr>
-        <h4 class="title is-5">Run a local exploratory benchmark</h4>
-        <div class="columns is-multiline">
-          <div class="column"><div class="field"><label class="label" for="bench-games">Games</label><div class="control"><input id="bench-games" class="input" type="number" min="2" max="20" value="10"></div></div></div>
-          <div class="column"><div class="field"><label class="label" for="bench-coverage">Coverage sets</label><div class="control"><input id="bench-coverage" class="input" type="number" min="2" max="24" value="8"></div></div></div>
-          <div class="column"><div class="field"><label class="label" for="bench-random">QuickPick sets</label><div class="control"><input id="bench-random" class="input" type="number" min="4" max="80" value="32"></div></div></div>
-          <div class="column"><div class="field"><label class="label" for="bench-trials">Shared draws</label><div class="control"><input id="bench-trials" class="input" type="number" min="300" max="2500" step="100" value="1000"></div></div></div>
-          <div class="column"><div class="field"><label class="label" for="bench-seed">Seed</label><div class="control"><input id="bench-seed" class="input" type="number" value="20260822"></div></div></div>
+    <section class="section py-5" id="certificates">
+      <div class="container">
+        <div class="mb-5"><span class="tag is-success">Exact results</span><h2 class="title is-3 mt-3">Portfolio probability without simulation noise</h2><p class="subtitle is-5">The reference Coverage portfolio has exact any-prize probability from complement dynamic programming. Division 4-or-better is exact when its ticket events are pairwise disjoint.</p></div>
+        <div id="certificates-grid" class="columns is-multiline">
+          <div class="column is-half-tablet is-one-quarter-desktop"><div class="box is-shadowless"><div class="level is-mobile"><div class="level-left"><p class="heading">Exact any-prize probability</p></div><div class="level-right"><span class="tag is-success">Exact</span></div></div><p class="title is-4 is-skeleton" id="cert-any-exact">00.0000%</p><p class="help" id="cert-any-exact-status">Loading exact count…</p></div></div>
+          <div class="column is-half-tablet is-one-quarter-desktop"><div class="box is-shadowless"><p class="heading">Certified lower bound</p><p class="title is-4 is-skeleton" id="cert-any-lower">00.0000%</p><p class="help" id="cert-any-upper">Loading bound…</p></div></div>
+          <div class="column is-half-tablet is-one-quarter-desktop"><div class="box is-shadowless"><div class="level is-mobile"><div class="level-left"><p class="heading">Division 4+ probability</p></div><div class="level-right"><span class="tag is-skeleton" id="cert-d4-badge">Checking</span></div></div><p class="title is-4 is-skeleton" id="cert-d4-exact">00.0000%</p><p class="help" id="cert-d4-status">Checking certificate…</p></div></div>
+          <div class="column is-half-tablet is-one-quarter-desktop"><div class="box is-shadowless"><p class="heading">Maximum ticket overlap</p><p class="title is-4 is-skeleton" id="cert-overlap">0</p><p class="help">≤1 makes ≥4-main events mutually exclusive in pairs.</p></div></div>
         </div>
-        <div class="buttons"><button class="button is-info" id="run-local-benchmark" type="button"><span class="icon"><i data-lucide="play"></i></span><span>Run local benchmark</span></button><button class="button is-light" id="download-local-benchmark" type="button" disabled><span class="icon"><i data-lucide="download"></i></span><span>JSON</span></button></div>
-        <progress class="progress is-info is-hidden" id="benchmark-progress" value="0" max="100">0%</progress>
-        <div id="benchmark-local-result"><div class="notification">Runs entirely in your browser and does not use historical number frequencies.</div></div>
+        <div class="columns">
+          <div class="column"><article class="message"><div class="message-header"><p><span class="icon"><i data-lucide="binary"></i></span> Exact any-prize algorithm</p></div><div class="message-body">Count six-ball draws where every ticket stays below three matches, then take the complement. States are integer counts; no draw simulation is needed.</div></article></div>
+          <div class="column"><article class="message"><div class="message-header"><p><span class="icon"><i data-lucide="shield-check"></i></span> Division 4 certificate</p></div><div class="message-body">Pairwise ticket overlap of at most one number makes ≥4-main events pairwise disjoint, reaching the sum-of-marginals upper bound.</div></article></div>
+        </div>
       </div>
-    </div></section>
+    </section>
 
-    <section class="section py-5"><div class="container"><div class="mb-5"><span class="tag is-dark is-light">Method</span><h2 class="title is-3 mt-3">Exact mathematics first, simulation second</h2></div><div class="columns is-multiline">
-      <div class="column is-one-third"><div class="box"><span class="tag is-success is-light">Exact</span><h3 class="title is-5 mt-3">Any-prize portfolio union</h3><p>Complement dynamic programming counts all eligible winning-main sets.</p></div></div>
-      <div class="column is-one-third"><div class="box"><span class="tag is-success is-light">Exact</span><h3 class="title is-5 mt-3">Pair intersections</h3><p>Two-ticket ≥3-main and ≥4-main event intersections are counted directly.</p></div></div>
-      <div class="column is-one-third"><div class="box"><span class="tag is-success is-light">Certified</span><h3 class="title is-5 mt-3">Bonferroni lower bound</h3><p>S1 − S2 is a rigorous lower bound and a cheap optimisation signal.</p></div></div>
-      <div class="column is-one-third"><div class="box"><span class="tag is-primary is-light">Optimal</span><h3 class="title is-5 mt-3">Division 4+ certificate</h3><p>Pairwise-disjoint ≥4-main events reach the universal upper bound.</p></div></div>
-      <div class="column is-one-third"><div class="box"><span class="tag is-info is-light">Simulated</span><h3 class="title is-5 mt-3">Shared draws</h3><p>Monte Carlo remains for exploratory metrics that are not solved exactly.</p></div></div>
-      <div class="column is-one-third"><div class="box"><span class="tag is-danger is-light">Rejected</span><h3 class="title is-5 mt-3">No sampled-training optimiser</h3><p>A sampled-training prototype overfit and failed to generalise, so it is not shipped.</p></div></div>
-    </div></div></section>
+    <section class="section py-5" id="evidence">
+      <div class="container">
+        <div class="mb-5"><span class="tag is-info">Comparisons</span><h2 class="title is-3 mt-3">Coverage against alternative portfolio populations</h2><p class="subtitle is-5">The repository benchmark compares independent portfolio seeds. Local browser runs are explicitly exploratory.</p></div>
+        <article class="message"><div class="message-header"><p><span class="icon"><i data-lucide="info"></i></span> Interpretation</p></div><div class="message-body">Probability-of-superiority is a benchmark statistic. It is not the probability that a strategy wins the lottery.</div></article>
+
+        <div id="portfolio-benchmark" class="box is-shadowless">
+          <div class="level"><div class="level-left"><div><span class="tag is-info">Multi-seed benchmark</span><h3 class="title is-4 mt-3">Coverage portfolios vs QuickPick distributions</h3><p class="subtitle is-6">Independent portfolio seeds are evaluated on the same simulated draws.</p></div></div><div class="level-right"><span class="tag">Distribution test</span></div></div>
+          <div id="benchmark-reference" aria-live="polite"><div class="skeleton-lines"><div></div><div></div><div></div><div></div></div></div>
+          <hr>
+          <h4 class="title is-5">Run a local exploratory benchmark</h4>
+          <div class="columns is-multiline">
+            <div class="column is-half-tablet is-one-fifth-desktop"><div class="field"><label class="label" for="bench-games">Games</label><div class="control"><input id="bench-games" class="input" type="number" min="2" max="20" value="10"></div></div></div>
+            <div class="column is-half-tablet is-one-fifth-desktop"><div class="field"><label class="label" for="bench-coverage">Coverage sets</label><div class="control"><input id="bench-coverage" class="input" type="number" min="2" max="24" value="8"></div></div></div>
+            <div class="column is-half-tablet is-one-fifth-desktop"><div class="field"><label class="label" for="bench-random">QuickPick sets</label><div class="control"><input id="bench-random" class="input" type="number" min="4" max="80" value="32"></div></div></div>
+            <div class="column is-half-tablet is-one-fifth-desktop"><div class="field"><label class="label" for="bench-trials">Shared draws</label><div class="control"><input id="bench-trials" class="input" type="number" min="300" max="2500" step="100" value="1000"></div></div></div>
+            <div class="column is-half-tablet is-one-fifth-desktop"><div class="field"><label class="label" for="bench-seed">Seed</label><div class="control"><input id="bench-seed" class="input" type="number" value="20260822"></div></div></div>
+          </div>
+          <div class="buttons is-flex-wrap-wrap"><button class="button is-info" id="run-local-benchmark" type="button"><span class="icon"><i data-lucide="play"></i></span><span>Run local benchmark</span></button><button class="button is-outlined" id="download-local-benchmark" type="button" disabled><span class="icon"><i data-lucide="download"></i></span><span>JSON</span></button></div>
+          <progress class="progress is-info is-hidden" id="benchmark-progress" value="0" max="100">0%</progress>
+          <div id="benchmark-local-result"><div class="notification">Runs entirely in your browser and does not use historical number frequencies.</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section py-5">
+      <div class="container">
+        <div class="mb-5"><span class="tag">Method</span><h2 class="title is-3 mt-3">Exact mathematics first, simulation second</h2></div>
+        <div class="columns is-multiline">
+          <div class="column is-half-tablet is-one-third-desktop"><div class="box is-shadowless"><span class="tag is-success">Exact</span><h3 class="title is-5 mt-3">Any-prize portfolio union</h3><p>Complement dynamic programming counts all eligible winning-main sets.</p></div></div>
+          <div class="column is-half-tablet is-one-third-desktop"><div class="box is-shadowless"><span class="tag is-success">Exact</span><h3 class="title is-5 mt-3">Pair intersections</h3><p>Two-ticket ≥3-main and ≥4-main event intersections are counted directly.</p></div></div>
+          <div class="column is-half-tablet is-one-third-desktop"><div class="box is-shadowless"><span class="tag is-success">Certified</span><h3 class="title is-5 mt-3">Bonferroni lower bound</h3><p>S1 − S2 is a rigorous lower bound and a cheap optimisation signal.</p></div></div>
+          <div class="column is-half-tablet is-one-third-desktop"><div class="box is-shadowless"><span class="tag is-primary">Optimal</span><h3 class="title is-5 mt-3">Division 4+ certificate</h3><p>Pairwise-disjoint ≥4-main events reach the universal upper bound.</p></div></div>
+          <div class="column is-half-tablet is-one-third-desktop"><div class="box is-shadowless"><span class="tag is-info">Simulated</span><h3 class="title is-5 mt-3">Shared draws</h3><p>Monte Carlo remains for exploratory metrics that are not solved exactly.</p></div></div>
+          <div class="column is-half-tablet is-one-third-desktop"><div class="box is-shadowless"><span class="tag is-danger">Rejected</span><h3 class="title is-5 mt-3">No sampled-training optimiser</h3><p>A sampled-training prototype overfit and failed to generalise, so it is not shipped.</p></div></div>
+        </div>
+      </div>
+    </section>
   </main>
 
   <footer class="footer"><div class="content has-text-centered"><p><strong>Lottery Lab</strong> · Open-source Saturday Lotto portfolio research. Not affiliated with The Lott.</p><p><a href="index.html">Saturday</a> · <a href="games.html">Games &amp; odds</a> · <a href="https://github.com/JDsnyke/saturday-tatts-lotto-scraper">GitHub</a></p><p class="is-size-7">More entries increase spend as well as probability. Portfolio optimisation does not turn lottery play into an investment.</p></div></footer>

--- a/games.html
+++ b/games.html
@@ -9,77 +9,111 @@
   <title>Games &amp; Odds · Lottery Lab</title>
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="manifest" href="assets/site.webmanifest">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
-  <script defer src="https://unpkg.com/lucide@1.33.0/dist/umd/lucide.js"></script>
+  <link rel="stylesheet" href="assets/vendor/bulma.min.css">
+  <script defer src="assets/vendor/lucide.js"></script>
   <script defer src="assets/ui.js"></script>
   <script defer src="assets/games.js"></script>
 </head>
 <body>
-  <nav class="navbar is-spaced has-shadow" role="navigation" aria-label="Primary navigation">
+  <nav class="navbar is-spaced" role="navigation" aria-label="Primary navigation">
     <div class="navbar-brand">
-      <a class="navbar-item" href="games.html"><strong>Lottery Lab</strong>&nbsp;<span class="tag is-link is-light">Games &amp; odds</span></a>
+      <a class="navbar-item px-3" href="games.html"><strong>Lottery Lab</strong>&nbsp;<span class="tag is-link">Games &amp; odds</span></a>
       <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="games-navbar"><span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span></a>
     </div>
-    <div id="games-navbar" class="navbar-menu">
+    <div id="games-navbar" class="navbar-menu p-2">
       <div class="navbar-start">
-        <a class="navbar-item" href="index.html"><span class="icon"><i data-lucide="ticket"></i></span><span>Saturday</span></a>
-        <a class="navbar-item is-selected" href="games.html" aria-current="page"><span class="icon"><i data-lucide="grid-2x2"></i></span><span>Games &amp; odds</span></a>
-        <a class="navbar-item" href="benchmark.html"><span class="icon"><i data-lucide="chart-no-axes-combined"></i></span><span>Benchmarks</span></a>
-        <a class="navbar-item" href="#calculators"><span class="icon"><i data-lucide="calculator"></i></span><span>Calculators</span></a>
+        <a class="navbar-item mx-1" href="index.html"><span class="icon"><i data-lucide="ticket"></i></span><span>Saturday</span></a>
+        <a class="navbar-item mx-1 is-selected" href="games.html" aria-current="page"><span class="icon"><i data-lucide="grid-2x2"></i></span><span>Games &amp; odds</span></a>
+        <a class="navbar-item mx-1" href="benchmark.html"><span class="icon"><i data-lucide="chart-no-axes-combined"></i></span><span>Benchmarks</span></a>
+        <a class="navbar-item mx-1" href="#calculators"><span class="icon"><i data-lucide="calculator"></i></span><span>Calculators</span></a>
       </div>
       <div class="navbar-end">
-        <div class="navbar-item"><span id="catalog-status" class="tag is-info is-light is-skeleton">Loading rules</span></div>
-        <div class="navbar-item"><button id="theme-toggle" class="button is-light" type="button" aria-label="Change theme"><span class="icon"><i id="theme-icon" data-lucide="monitor"></i></span><span>Theme</span></button></div>
+        <div class="navbar-item mx-1"><span id="catalog-status" class="tag is-info is-skeleton">Loading rules</span></div>
+        <div class="navbar-item mx-1"><button id="theme-toggle" class="button is-fullwidth" type="button" aria-label="Change theme"><span class="icon"><i id="theme-icon" data-lucide="monitor"></i></span><span>Theme</span></button></div>
       </div>
     </div>
   </nav>
 
   <main>
     <section class="hero">
-      <div class="hero-body py-5"><div class="container"><div class="columns is-vcentered mx-0">
-        <div class="column is-three-fifths"><span class="tag is-link is-light mb-4">Australian game catalogue</span><h1 class="title is-2">Game rules and odds, side by side</h1><p class="subtitle is-5">Compare current Australian lottery mechanics without forcing unlike products into the same formula. Jurisdiction, operator source and variable raffle capacity stay visible.</p><div class="buttons"><a class="button is-link is-medium" href="#catalog"><span class="icon"><i data-lucide="list-filter"></i></span><span>Browse games</span></a><a class="button is-light is-medium" href="#calculators"><span class="icon"><i data-lucide="calculator"></i></span><span>Calculators</span></a></div></div>
-        <div class="column"><div class="box"><h2 class="title is-4">Different games, different maths</h2><div class="content"><ul><li><strong>Powerball:</strong> two independent pools</li><li><strong>Lucky Lotteries:</strong> raffle mechanics</li><li><strong>Keno:</strong> spot-size dependent</li><li><strong>Scratch games:</strong> print-run dependent</li></ul></div><div class="notification is-info is-light">Top-prize odds do not capture ticket price, prize size, payout rules, sharing, annuity terms or prize inventory.</div></div></div>
-      </div></div></div>
+      <div class="hero-body py-5">
+        <div class="container">
+          <div class="columns is-vcentered mx-0">
+            <div class="column is-three-fifths px-3">
+              <span class="tag is-link mb-4">Australian game catalogue</span>
+              <h1 class="title is-2">Game rules and odds, side by side</h1>
+              <p class="subtitle is-5">Compare Australian lottery mechanics without forcing unlike products into the same formula. Jurisdiction, operator source and variable raffle capacity stay explicit.</p>
+              <div class="buttons is-flex-wrap-wrap">
+                <a class="button is-link is-medium" href="#catalog"><span class="icon"><i data-lucide="list-filter"></i></span><span>Browse games</span></a>
+                <a class="button is-medium is-outlined" href="#calculators"><span class="icon"><i data-lucide="calculator"></i></span><span>Calculators</span></a>
+              </div>
+            </div>
+            <div class="column px-3">
+              <div class="box is-shadowless">
+                <h2 class="title is-4">Different games, different maths</h2>
+                <div class="content"><ul><li><strong>Powerball:</strong> two independent pools</li><li><strong>Lucky Lotteries:</strong> raffle mechanics</li><li><strong>Keno:</strong> spot-size dependent</li><li><strong>Scratch games:</strong> print-run dependent</li></ul></div>
+                <div class="notification mb-0">Top-prize odds do not include ticket price, prize size, sharing, annuity terms or prize inventory.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </section>
 
-    <section class="section py-5" id="catalog"><div class="container">
-      <div class="mb-5"><span class="tag is-link is-light">Catalogue</span><h2 class="title is-3 mt-3">Current games and alternatives</h2><p class="subtitle is-5">Computed values follow a verified draw mechanism. Variable or reported products remain operator-sourced.</p></div>
-      <div class="box"><div class="columns is-multiline">
-        <div class="column"><div class="field"><label class="label" for="game-operator">Operator</label><div class="control"><div class="select is-fullwidth"><select id="game-operator"><option value="">All operators</option></select></div></div></div></div>
-        <div class="column"><div class="field"><label class="label" for="game-mechanic">Mechanic</label><div class="control"><div class="select is-fullwidth"><select id="game-mechanic"><option value="">All mechanics</option></select></div></div></div></div>
-        <div class="column"><div class="field"><label class="label" for="game-jurisdiction">Jurisdiction</label><div class="control"><div class="select is-fullwidth"><select id="game-jurisdiction"><option value="">All jurisdictions</option><option>QLD</option><option>NSW</option><option>ACT</option><option>VIC</option><option>TAS</option><option>SA</option><option>NT</option><option>WA</option></select></div></div></div></div>
-        <div class="column"><div class="field"><label class="label" for="game-sort">Sort</label><div class="control"><div class="select is-fullwidth"><select id="game-sort"><option value="name">Name</option><option value="odds">Easiest top-prize odds first</option></select></div></div></div></div>
-      </div></div>
-      <div class="level"><div class="level-left"><strong id="game-count">Loading…</strong></div><div class="level-right"><p class="is-size-7 has-text-grey">Official reported odds are rounded where the operator publishes them that way.</p></div></div>
-      <div id="game-grid" class="columns is-multiline" aria-live="polite">
-        <div class="column is-half"><div class="card is-skeleton"><div class="card-content">Loading game</div></div></div>
-        <div class="column is-half"><div class="card is-skeleton"><div class="card-content">Loading game</div></div></div>
-        <div class="column is-half"><div class="card is-skeleton"><div class="card-content">Loading game</div></div></div>
-        <div class="column is-half"><div class="card is-skeleton"><div class="card-content">Loading game</div></div></div>
+    <section class="section py-5" id="catalog">
+      <div class="container">
+        <div class="mb-5"><span class="tag is-link">Catalogue</span><h2 class="title is-3 mt-3">Current games and alternatives</h2><p class="subtitle is-5">Computed values follow a verified draw mechanism. Variable or reported products remain operator-sourced.</p></div>
+        <div class="box is-shadowless">
+          <div class="columns is-multiline">
+            <div class="column is-half-tablet is-one-quarter-desktop"><div class="field"><label class="label" for="game-operator">Operator</label><div class="control"><div class="select is-fullwidth"><select id="game-operator"><option value="">All operators</option></select></div></div></div></div>
+            <div class="column is-half-tablet is-one-quarter-desktop"><div class="field"><label class="label" for="game-mechanic">Mechanic</label><div class="control"><div class="select is-fullwidth"><select id="game-mechanic"><option value="">All mechanics</option></select></div></div></div></div>
+            <div class="column is-half-tablet is-one-quarter-desktop"><div class="field"><label class="label" for="game-jurisdiction">Jurisdiction</label><div class="control"><div class="select is-fullwidth"><select id="game-jurisdiction"><option value="">All jurisdictions</option><option>QLD</option><option>NSW</option><option>ACT</option><option>VIC</option><option>TAS</option><option>SA</option><option>NT</option><option>WA</option></select></div></div></div></div>
+            <div class="column is-half-tablet is-one-quarter-desktop"><div class="field"><label class="label" for="game-sort">Sort</label><div class="control"><div class="select is-fullwidth"><select id="game-sort"><option value="name">Name</option><option value="odds">Easiest top-prize odds first</option></select></div></div></div></div>
+          </div>
+        </div>
+        <div class="level is-mobile"><div class="level-left"><strong id="game-count">Loading…</strong></div></div>
+        <p class="is-size-7 mb-4">Published operator odds are kept as reported when the product does not have one fixed combinatorial denominator.</p>
+        <div id="game-grid" class="columns is-multiline mx-0" aria-live="polite">
+          <div class="column is-half px-2"><div class="box is-shadowless is-skeleton">Loading game</div></div>
+          <div class="column is-half px-2"><div class="box is-shadowless is-skeleton">Loading game</div></div>
+        </div>
       </div>
-    </div></section>
+    </section>
 
-    <section class="section py-5" id="calculators"><div class="container">
-      <div class="mb-5"><span class="tag is-primary is-light">Calculators</span><h2 class="title is-3 mt-3">Use the probability model that matches the game</h2><p class="subtitle is-5">Repeated draws, Keno spots and ordered digits are different experiments.</p></div>
-      <div class="columns is-multiline">
-        <div class="column is-one-third"><article class="card"><div class="card-content"><div class="media"><div class="media-left"><span class="icon is-large"><i data-lucide="calendar-range"></i></span></div><div class="media-content"><p class="title is-5">Set for Life</p><p class="subtitle is-7">Repeated independent draws</p></div></div><div class="content"><p>A standard purchase covers seven consecutive daily draws. Cumulative probability is <code>1-(1-p)^d</code>.</p><div class="field"><label class="label" for="sfl-draws">Number of draws</label><div class="control"><input id="sfl-draws" class="input" type="number" min="1" max="365" value="7" inputmode="numeric"></div></div><hr><p class="heading">Single draw</p><p class="title is-5" id="sfl-single">—</p><p class="heading" id="sfl-label">—</p><p class="title is-5" id="sfl-cumulative">—</p><p class="help" id="sfl-probability">—</p></div></div></article></div>
-        <div class="column is-one-third"><article class="card"><div class="card-content"><div class="media"><div class="media-left"><span class="icon is-large"><i data-lucide="circle-dot"></i></span></div><div class="media-content"><p class="title is-5">Keno · South Australia</p><p class="subtitle is-7">Hypergeometric Spot probability</p></div></div><div class="content"><p>For a fixed Spot selection, exact matches follow a hypergeometric distribution because 20 numbers are drawn without replacement from 80.</p><div class="field"><label class="label" for="keno-spot">Spot size</label><div class="control"><input id="keno-spot" class="input" type="number" min="1" max="10" value="10" inputmode="numeric"></div></div><hr><p class="heading" id="keno-label">—</p><p class="title is-5" id="keno-result">—</p><p class="help" id="keno-probability">—</p></div></div></article></div>
-        <div class="column is-one-third"><article class="card"><div class="card-content"><div class="media"><div class="media-left"><span class="icon is-large"><i data-lucide="hash"></i></span></div><div class="media-content"><p class="title is-5">Lotterywest Cash 3</p><p class="subtitle is-7">Exact vs Any Order</p></div></div><div class="content"><p>Exact Order has 1,000 possible strings. Any Order depends on whether the multiset has 1, 3 or 6 distinct permutations.</p><div class="field"><label class="label" for="cash3-digits">Three digits</label><div class="control"><input id="cash3-digits" class="input" type="text" maxlength="3" value="223" inputmode="numeric" pattern="[0-9]{3}"></div></div><hr><p class="heading">Exact Order</p><p class="title is-5">1 in 1,000</p><p class="heading">Any Order</p><p class="title is-5" id="cash3-any">—</p><p class="help" id="cash3-orders">—</p></div></div></article></div>
+    <section class="section py-5" id="calculators">
+      <div class="container">
+        <div class="mb-5"><span class="tag is-primary">Calculators</span><h2 class="title is-3 mt-3">Use the probability model that matches the game</h2><p class="subtitle is-5">Repeated draws, Keno spots and ordered digits are different experiments.</p></div>
+        <div class="columns is-multiline">
+          <div class="column is-one-third-desktop"><article class="card is-shadowless"><div class="card-content"><div class="media"><div class="media-left"><span class="icon is-large"><i data-lucide="calendar-range"></i></span></div><div class="media-content"><p class="title is-5">Set for Life</p><p class="subtitle is-7">Repeated independent draws</p></div></div><div class="content"><p>A standard purchase covers seven consecutive daily draws. Cumulative probability is <code>1-(1-p)^d</code>.</p><div class="field"><label class="label" for="sfl-draws">Number of draws</label><div class="control"><input id="sfl-draws" class="input" type="number" min="1" max="365" value="7" inputmode="numeric"></div></div><hr><p class="heading">Single draw</p><p class="title is-5" id="sfl-single">—</p><p class="heading" id="sfl-label">—</p><p class="title is-5" id="sfl-cumulative">—</p><p class="help" id="sfl-probability">—</p></div></div></article></div>
+          <div class="column is-one-third-desktop"><article class="card is-shadowless"><div class="card-content"><div class="media"><div class="media-left"><span class="icon is-large"><i data-lucide="circle-dot"></i></span></div><div class="media-content"><p class="title is-5">Keno · South Australia</p><p class="subtitle is-7">Hypergeometric Spot probability</p></div></div><div class="content"><p>For a fixed Spot selection, exact matches follow a hypergeometric distribution because 20 numbers are drawn without replacement from 80.</p><div class="field"><label class="label" for="keno-spot">Spot size</label><div class="control"><input id="keno-spot" class="input" type="number" min="1" max="10" value="10" inputmode="numeric"></div></div><hr><p class="heading" id="keno-label">—</p><p class="title is-5" id="keno-result">—</p><p class="help" id="keno-probability">—</p></div></div></article></div>
+          <div class="column is-one-third-desktop"><article class="card is-shadowless"><div class="card-content"><div class="media"><div class="media-left"><span class="icon is-large"><i data-lucide="hash"></i></span></div><div class="media-content"><p class="title is-5">Lotterywest Cash 3</p><p class="subtitle is-7">Exact vs Any Order</p></div></div><div class="content"><p>Exact Order has 1,000 possible strings. Any Order depends on whether the multiset has 1, 3 or 6 distinct permutations.</p><div class="field"><label class="label" for="cash3-digits">Three digits</label><div class="control"><input id="cash3-digits" class="input" type="text" maxlength="3" value="223" inputmode="numeric" pattern="[0-9]{3}"></div></div><hr><p class="heading">Exact Order</p><p class="title is-5">1 in 1,000</p><p class="heading">Any Order</p><p class="title is-5" id="cash3-any">—</p><p class="help" id="cash3-orders">—</p></div></div></article></div>
+        </div>
       </div>
-    </div></section>
+    </section>
 
-    <section class="section py-5" id="mechanics"><div class="container">
-      <div class="mb-5"><span class="tag is-warning is-light">Mechanics</span><h2 class="title is-3 mt-3">Several probability families</h2><p class="subtitle is-5">The Saturday portfolio optimiser stays specialised; the shared catalogue models each probability experiment first.</p></div>
-      <div class="columns is-multiline">
-        <div class="column is-one-quarter-desktop is-half-tablet"><div class="box"><span class="icon"><i data-lucide="circle-dot-dashed"></i></span><h3 class="title is-5 mt-3">One-pool draws</h3><p>Saturday Lotto, Weekday Windfall, Oz Lotto, Set for Life and Millionaire Medley.</p></div></div>
-        <div class="column is-one-quarter-desktop is-half-tablet"><div class="box"><span class="icon"><i data-lucide="split"></i></span><h3 class="title is-5 mt-3">Two pools</h3><p>Powerball combines a seven-number main selection with a separate Powerball pool.</p></div></div>
-        <div class="column is-one-quarter-desktop is-half-tablet"><div class="box"><span class="icon"><i data-lucide="list-ordered"></i></span><h3 class="title is-5 mt-3">Ordered games</h3><p>Super 66, Cash 3 and Lotto Strike require order-sensitive probability models.</p></div></div>
-        <div class="column is-one-quarter-desktop is-half-tablet"><div class="box"><span class="icon"><i data-lucide="ticket-check"></i></span><h3 class="title is-5 mt-3">Variable products</h3><p>Raffles and scratch products need pool or print-run-specific metadata.</p></div></div>
+    <section class="section py-5" id="mechanics">
+      <div class="container">
+        <div class="mb-5"><span class="tag is-warning">Mechanics</span><h2 class="title is-3 mt-3">Several probability families</h2><p class="subtitle is-5">The Saturday portfolio optimiser stays specialised; the shared catalogue models each probability experiment first.</p></div>
+        <div class="columns is-multiline">
+          <div class="column is-half-tablet is-one-quarter-desktop"><div class="box is-shadowless"><span class="icon"><i data-lucide="circle-dot-dashed"></i></span><h3 class="title is-5 mt-3">One-pool draws</h3><p>Saturday Lotto, Weekday Windfall, Oz Lotto, Set for Life and Millionaire Medley.</p></div></div>
+          <div class="column is-half-tablet is-one-quarter-desktop"><div class="box is-shadowless"><span class="icon"><i data-lucide="split"></i></span><h3 class="title is-5 mt-3">Two pools</h3><p>Powerball combines a seven-number main selection with a separate Powerball pool.</p></div></div>
+          <div class="column is-half-tablet is-one-quarter-desktop"><div class="box is-shadowless"><span class="icon"><i data-lucide="list-ordered"></i></span><h3 class="title is-5 mt-3">Ordered games</h3><p>Super 66, Cash 3 and Lotto Strike require order-sensitive probability models.</p></div></div>
+          <div class="column is-half-tablet is-one-quarter-desktop"><div class="box is-shadowless"><span class="icon"><i data-lucide="ticket-check"></i></span><h3 class="title is-5 mt-3">Variable products</h3><p>Raffles and scratch products need pool or print-run-specific metadata.</p></div></div>
+        </div>
+        <article class="message"><div class="message-header"><p><span class="icon"><i data-lucide="scale"></i></span> Interpretation</p></div><div class="message-body">Easier top-prize odds do not automatically mean better value. Ticket cost, prize amounts, payout rules, sharing and annuity terms also matter.</div></article>
       </div>
-      <article class="message is-info"><div class="message-header"><p><span class="icon"><i data-lucide="scale"></i></span> Interpretation</p></div><div class="message-body">Easier top-prize odds do not automatically mean better value. Ticket cost, prize amounts, payout rules, sharing and annuity terms also matter.</div></article>
-    </div></section>
+    </section>
 
-    <section class="section py-5"><div class="container"><div class="mb-5"><span class="tag is-success is-light">Sources</span><h2 class="title is-3 mt-3">Operator rules first</h2><p class="subtitle is-5">Core mechanics and published odds were rechecked against current operator pages. Unsupported lower-division rules stay uncomputed.</p></div><div class="columns"><div class="column"><div class="box"><h3 class="title is-5">The Lott</h3><p>Official Help Centre odds cross-check current Division 1 and jackpot denominators.</p></div></div><div class="column"><div class="box"><h3 class="title is-5">Lotterywest</h3><p>WA game pages independently verify national and WA-specific mechanics.</p></div></div><div class="column"><div class="box"><h3 class="title is-5">Jurisdiction</h3><p>Availability is kept explicit rather than implied nationally.</p></div></div></div></div></section>
+    <section class="section py-5">
+      <div class="container">
+        <div class="mb-5"><span class="tag is-success">Sources</span><h2 class="title is-3 mt-3">Operator rules first</h2><p class="subtitle is-5">Core mechanics and published odds are tied to captured operator sources. Unsupported lower-division rules stay uncomputed.</p></div>
+        <div class="columns">
+          <div class="column"><div class="box is-shadowless"><h3 class="title is-5">The Lott</h3><p>Official Help Centre odds cross-check current Division 1 and jackpot denominators.</p></div></div>
+          <div class="column"><div class="box is-shadowless"><h3 class="title is-5">Lotterywest</h3><p>WA game pages independently verify national and WA-specific mechanics.</p></div></div>
+          <div class="column"><div class="box is-shadowless"><h3 class="title is-5">Jurisdiction</h3><p>Availability is kept explicit rather than implied nationally.</p></div></div>
+        </div>
+      </div>
+    </section>
   </main>
 
   <footer class="footer"><div class="content has-text-centered"><p><strong>Lottery Lab</strong> · Open-source Australian lottery probability research. Not affiliated with The Lott or Lotterywest.</p><p><a href="index.html">Saturday</a> · <a href="benchmark.html">Benchmarks</a> · <a href="https://github.com/JDsnyke/saturday-tatts-lotto-scraper">GitHub</a></p><p class="is-size-7">Lottery outcomes are random. More entries cost more money.</p></div></footer>

--- a/index.html
+++ b/index.html
@@ -9,28 +9,28 @@
   <title>Saturday Lotto · Lottery Lab</title>
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="manifest" href="assets/site.webmanifest">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css">
-  <script defer src="https://unpkg.com/lucide@1.33.0/dist/umd/lucide.js"></script>
+  <link rel="stylesheet" href="assets/vendor/bulma.min.css">
+  <script defer src="assets/vendor/lucide.js"></script>
   <script defer src="assets/ui.js"></script>
   <script defer src="assets/app.js"></script>
 </head>
 <body>
-  <nav class="navbar is-spaced has-shadow" role="navigation" aria-label="Primary navigation">
+  <nav class="navbar is-spaced" role="navigation" aria-label="Primary navigation">
     <div class="navbar-brand">
-      <a class="navbar-item" href="index.html"><strong>Lottery Lab</strong>&nbsp;<span class="tag is-primary is-light">Saturday Lotto</span></a>
+      <a class="navbar-item px-3" href="index.html"><strong>Lottery Lab</strong>&nbsp;<span class="tag is-primary">Saturday Lotto</span></a>
       <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="main-navbar"><span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span><span aria-hidden="true"></span></a>
     </div>
-    <div id="main-navbar" class="navbar-menu">
+    <div id="main-navbar" class="navbar-menu p-2">
       <div class="navbar-start">
-        <a class="navbar-item is-selected" href="index.html" aria-current="page"><span class="icon"><i data-lucide="ticket"></i></span><span>Saturday</span></a>
-        <a class="navbar-item" href="games.html"><span class="icon"><i data-lucide="grid-2x2"></i></span><span>Games &amp; odds</span></a>
-        <a class="navbar-item" href="benchmark.html"><span class="icon"><i data-lucide="chart-no-axes-combined"></i></span><span>Benchmarks</span></a>
-        <a class="navbar-item" href="#tickets"><span class="icon"><i data-lucide="layers-3"></i></span><span>Portfolio</span></a>
-        <a class="navbar-item" href="#draws"><span class="icon"><i data-lucide="history"></i></span><span>Draw history</span></a>
+        <a class="navbar-item mx-1 is-selected" href="index.html" aria-current="page"><span class="icon"><i data-lucide="ticket"></i></span><span>Saturday</span></a>
+        <a class="navbar-item mx-1" href="games.html"><span class="icon"><i data-lucide="grid-2x2"></i></span><span>Games &amp; odds</span></a>
+        <a class="navbar-item mx-1" href="benchmark.html"><span class="icon"><i data-lucide="chart-no-axes-combined"></i></span><span>Benchmarks</span></a>
+        <a class="navbar-item mx-1" href="#tickets"><span class="icon"><i data-lucide="layers-3"></i></span><span>Portfolio</span></a>
+        <a class="navbar-item mx-1" href="#draws"><span class="icon"><i data-lucide="history"></i></span><span>Draw history</span></a>
       </div>
       <div class="navbar-end">
-        <div class="navbar-item"><span id="header-data-status" class="tag is-info is-light is-skeleton">Loading data</span></div>
-        <div class="navbar-item"><button id="theme-toggle" class="button is-light" type="button" aria-label="Change theme"><span class="icon"><i id="theme-icon" data-lucide="monitor"></i></span><span>Theme</span></button></div>
+        <div class="navbar-item mx-1"><span id="header-data-status" class="tag is-info is-skeleton">Loading data</span></div>
+        <div class="navbar-item mx-1"><button id="theme-toggle" class="button is-fullwidth" type="button" aria-label="Change theme"><span class="icon"><i id="theme-icon" data-lucide="monitor"></i></span><span>Theme</span></button></div>
       </div>
     </div>
   </nav>
@@ -40,19 +40,19 @@
       <div class="hero-body py-5">
         <div class="container">
           <div class="columns is-vcentered mx-0">
-            <div class="column is-three-fifths">
-              <p class="tag is-primary is-light mb-4">Saturday Lotto / TattsLotto</p>
+            <div class="column is-three-fifths px-3">
+              <span class="tag is-primary mb-4">Saturday Lotto / TattsLotto</span>
               <h1 class="title is-2">Saturday Lotto probability &amp; portfolio tools</h1>
               <p class="subtitle is-5">Exact odds, multi-entry coverage, draw history and diagnostics. Historical frequencies are descriptive and never rank future numbers.</p>
-              <div class="buttons">
+              <div class="buttons is-flex-wrap-wrap">
                 <a class="button is-primary is-medium" href="#planner"><span class="icon"><i data-lucide="calculator"></i></span><span>Probability planner</span></a>
-                <a class="button is-light is-medium" href="#tickets"><span class="icon"><i data-lucide="layers-3"></i></span><span>Build portfolio</span></a>
+                <a class="button is-medium is-outlined" href="#tickets"><span class="icon"><i data-lucide="layers-3"></i></span><span>Build portfolio</span></a>
               </div>
               <div class="tags mt-5"><span class="tag">Exact odds</span><span class="tag">Portfolio overlap</span><span class="tag">Source-checked data</span><span class="tag">No predictive scoring</span></div>
             </div>
-            <div class="column">
-              <div class="box">
-                <div class="level is-mobile"><div class="level-left"><strong>Standard game</strong></div><div class="level-right"><span class="tag is-success is-light">Exact</span></div></div>
+            <div class="column px-3">
+              <div class="box is-shadowless">
+                <div class="level is-mobile"><div class="level-left"><strong>Standard game</strong></div><div class="level-right"><span class="tag is-success">Exact</span></div></div>
                 <p class="heading">Division 1 odds</p>
                 <p class="title is-2 is-skeleton" id="hero-odds">1 in 8,145,060</p>
                 <progress id="hero-probability-bar" class="progress is-primary" value="1" max="100">1%</progress>
@@ -62,7 +62,7 @@
                   <div class="column is-half"><p class="heading">Draw</p><p class="title is-5">6 + 2 / 45</p></div>
                   <div class="column is-half"><p class="heading">Selection edge</p><p class="title is-5">None for Div 1</p></div>
                 </div>
-                <div class="notification is-info is-light mb-0">Every six-number combination has the same Division 1 chance. Portfolio structure only changes overlap between the games you own.</div>
+                <div class="notification mb-0">Every six-number combination has the same Division 1 chance. Portfolio structure only changes overlap between the games you own.</div>
               </div>
             </div>
           </div>
@@ -73,20 +73,20 @@
     <section class="section py-5">
       <div class="container">
         <div class="columns is-multiline">
-          <div class="column is-one-quarter-desktop is-half-tablet"><div class="box"><p class="heading">Validated draws</p><p class="title is-4 is-skeleton" id="metric-draws">0000</p><p class="is-size-7 has-text-grey" id="metric-range">Loading dataset…</p></div></div>
-          <div class="column is-one-quarter-desktop is-half-tablet"><div class="box"><p class="heading">Latest draw</p><p class="title is-4 is-skeleton" id="metric-latest">0000-00-00</p><p class="is-size-7 has-text-grey" id="metric-freshness">Checking freshness…</p></div></div>
-          <div class="column is-one-quarter-desktop is-half-tablet"><div class="box"><p class="heading">Distribution entropy</p><p class="title is-4 is-skeleton" id="metric-entropy">0.0000</p><p class="is-size-7 has-text-grey">1.0000 = perfectly even history</p></div></div>
-          <div class="column is-one-quarter-desktop is-half-tablet"><div class="box"><p class="heading">Largest historical |z|</p><p class="title is-4 is-skeleton" id="metric-z">0.00</p><p class="is-size-7 has-text-grey">Audit signal, not a forecast</p></div></div>
+          <div class="column is-half-tablet is-one-quarter-desktop"><div class="box is-shadowless"><p class="heading">Validated draws</p><p class="title is-4 is-skeleton" id="metric-draws">0000</p><p class="help" id="metric-range">Loading dataset…</p></div></div>
+          <div class="column is-half-tablet is-one-quarter-desktop"><div class="box is-shadowless"><p class="heading">Latest draw</p><p class="title is-4 is-skeleton" id="metric-latest">0000-00-00</p><p class="help" id="metric-freshness">Checking freshness…</p></div></div>
+          <div class="column is-half-tablet is-one-quarter-desktop"><div class="box is-shadowless"><p class="heading">Distribution entropy</p><p class="title is-4 is-skeleton" id="metric-entropy">0.0000</p><p class="help">1.0000 = perfectly even history</p></div></div>
+          <div class="column is-half-tablet is-one-quarter-desktop"><div class="box is-shadowless"><p class="heading">Largest historical |z|</p><p class="title is-4 is-skeleton" id="metric-z">0.00</p><p class="help">Audit signal, not a forecast</p></div></div>
         </div>
-        <article class="message is-warning"><div class="message-header"><p><span class="icon"><i data-lucide="info"></i></span> Historical data</p></div><div class="message-body"><strong>Historical frequency is descriptive, not predictive.</strong> Frequency, streaks and pair counts help inspect the dataset. They are excluded from ticket generation because a fair next draw does not remember previous draws.</div></article>
+        <article class="message"><div class="message-header"><p><span class="icon"><i data-lucide="info"></i></span> Historical data</p></div><div class="message-body"><strong>Historical frequency is descriptive, not predictive.</strong> Frequency, streaks and pair counts help inspect the dataset. They are excluded from ticket generation because a fair next draw does not remember previous draws.</div></article>
       </div>
     </section>
 
     <section class="section py-5" id="planner">
       <div class="container">
-        <div class="mb-5"><p class="tag is-info is-light">Planner</p><h2 class="title is-3 mt-3">Entries, systems and repeated draws</h2><p class="subtitle is-5">Compare distinct standard games, System entries and repeated independent draws without mixing different kinds of exposure.</p></div>
-        <div class="columns is-variable is-6">
-          <div class="column is-one-third"><div class="box">
+        <div class="mb-5"><span class="tag is-info">Planner</span><h2 class="title is-3 mt-3">Entries, systems and repeated draws</h2><p class="subtitle is-5">Compare distinct standard games, System entries and repeated independent draws without mixing different kinds of exposure.</p></div>
+        <div class="columns is-variable is-5">
+          <div class="column is-one-third-desktop"><div class="box is-shadowless">
             <div class="field"><label class="label" for="planner-games">Distinct standard games</label><div class="control"><input id="planner-games" class="input" type="number" min="1" max="200" value="10" step="1"></div><p class="help">Current value: <output id="planner-games-output" for="planner-games">10</output></p></div>
             <div class="field"><label class="label" for="planner-draws">Independent draws</label><div class="control"><input id="planner-draws" class="input" type="number" min="1" max="520" value="1" step="1"></div><p class="help">Current value: <output id="planner-draws-output" for="planner-draws">1</output></p></div>
             <div class="field"><label class="label" for="system-size">System numbers</label><div class="control"><div class="select is-fullwidth"><select id="system-size"><option value="6">System 6</option><option value="7">System 7</option><option value="8" selected>System 8</option><option value="9">System 9</option><option value="10">System 10</option><option value="11">System 11</option><option value="12">System 12</option><option value="13">System 13</option><option value="14">System 14</option><option value="15">System 15</option><option value="16">System 16</option><option value="17">System 17</option><option value="18">System 18</option><option value="19">System 19</option><option value="20">System 20</option></select></div></div></div>
@@ -94,12 +94,12 @@
           </div></div>
           <div class="column">
             <div class="columns is-multiline">
-              <div class="column is-one-third"><div class="box"><p class="heading">Per-draw Div 1 chance</p><p class="title is-5" id="planner-per-draw">—</p><p class="help" id="planner-per-draw-odds">—</p></div></div>
-              <div class="column is-one-third"><div class="box"><p class="heading">Across selected draws</p><p class="title is-5" id="planner-cumulative">—</p><p class="help" id="planner-cumulative-odds">—</p></div></div>
-              <div class="column is-one-third"><div class="box"><p class="heading" id="system-label">System 8 contains</p><p class="title is-5" id="system-combinations">28</p><p class="help">standard combinations</p></div></div>
+              <div class="column is-one-third-desktop"><div class="box is-shadowless"><p class="heading">Per-draw Div 1 chance</p><p class="title is-5" id="planner-per-draw">—</p><p class="help" id="planner-per-draw-odds">—</p></div></div>
+              <div class="column is-one-third-desktop"><div class="box is-shadowless"><p class="heading">Across selected draws</p><p class="title is-5" id="planner-cumulative">—</p><p class="help" id="planner-cumulative-odds">—</p></div></div>
+              <div class="column is-one-third-desktop"><div class="box is-shadowless"><p class="heading" id="system-label">System 8 contains</p><p class="title is-5" id="system-combinations">28</p><p class="help">standard combinations</p></div></div>
             </div>
-            <div class="box"><div class="level"><div class="level-left"><div><h3 class="title is-5 mb-1">Exact standard-game prize probabilities</h3><p class="is-size-7 has-text-grey">Six winning, two supplementary and 37 other balls.</p></div></div><div class="level-right"><span class="tag is-success is-light">Exact</span></div></div><div class="table-container"><table class="table is-fullwidth is-striped is-hoverable"><thead><tr><th>Division</th><th>Requirement</th><th class="is-hidden-mobile">Probability</th><th>Odds</th></tr></thead><tbody id="prize-table-body"></tbody></table></div></div>
-            <div class="box"><h3 class="title is-5">Main-number match distribution</h3><p class="is-size-7 has-text-grey mb-4">Exactly 0–6 winning numbers for one standard game.</p><div id="match-bars" aria-label="Probability distribution for main-number matches"><div class="skeleton-lines"><div></div><div></div><div></div><div></div></div></div></div>
+            <div class="box is-shadowless"><div class="level"><div class="level-left"><div><h3 class="title is-5 mb-1">Exact standard-game prize probabilities</h3><p class="help">Six winning, two supplementary and 37 other balls.</p></div></div><div class="level-right"><span class="tag is-success">Exact</span></div></div><div class="table-container"><table class="table is-fullwidth is-striped is-hoverable"><thead><tr><th>Division</th><th>Requirement</th><th class="is-hidden-mobile">Probability</th><th>Odds</th></tr></thead><tbody id="prize-table-body"></tbody></table></div></div>
+            <div class="box is-shadowless"><h3 class="title is-5">Main-number match distribution</h3><p class="help mb-4">Exactly 0–6 winning numbers for one standard game.</p><div id="match-bars" aria-label="Probability distribution for main-number matches"><div class="skeleton-lines"><div></div><div></div><div></div><div></div></div></div></div>
           </div>
         </div>
       </div>
@@ -107,29 +107,29 @@
 
     <section class="section py-5" id="tickets">
       <div class="container">
-        <div class="mb-5"><p class="tag is-primary is-light">Portfolio</p><h2 class="title is-3 mt-3">Build lower-overlap ticket sets</h2><p class="subtitle is-5">Coverage adds new quadruples, triples and pairs. QuickPick is the unbiased baseline. Anti-crowding concerns possible prize sharing, not draw probability.</p></div>
-        <div class="columns is-variable is-6">
-          <div class="column is-one-third"><div class="box">
+        <div class="mb-5"><span class="tag is-primary">Portfolio</span><h2 class="title is-3 mt-3">Build lower-overlap ticket sets</h2><p class="subtitle is-5">Coverage adds new quadruples, triples and pairs. QuickPick is the unbiased baseline. Anti-crowding concerns possible prize sharing, not draw probability.</p></div>
+        <div class="columns is-variable is-5">
+          <div class="column is-one-third-desktop"><div class="box is-shadowless">
             <div class="field"><label class="label" for="ticket-count">Number of games</label><div class="control"><input id="ticket-count" class="input" type="number" min="1" max="40" value="10" step="1"></div><p class="help">Current value: <output id="ticket-count-output" for="ticket-count">10</output></p></div>
             <div class="field"><label class="label">Generation mode</label><div class="control"><label class="radio"><input type="radio" name="mode" value="coverage" checked> Combinatorial coverage</label></div><p class="help mb-3">Adds new quadruples, triples and pairs, then reduces overlap.</p><div class="control"><label class="radio"><input type="radio" name="mode" value="random"> Uniform QuickPick</label></div><p class="help mb-3">Random distinct six-number combinations.</p><div class="control"><label class="radio"><input type="radio" name="mode" value="anti-crowding"> Anti-crowding</label></div><p class="help">Experimental prize-sharing heuristic. Same draw odds.</p></div>
-            <div class="buttons"><button class="button is-primary is-fullwidth" id="generate-tickets" type="button"><span class="icon"><i data-lucide="wand-sparkles"></i></span><span>Generate portfolio</span></button><button class="button is-light" id="copy-share" type="button"><span class="icon"><i data-lucide="link"></i></span><span>Copy link</span></button><button class="button is-light" id="download-tickets" type="button"><span class="icon"><i data-lucide="download"></i></span><span>CSV</span></button></div>
+            <div class="buttons is-flex-wrap-wrap"><button class="button is-primary is-fullwidth" id="generate-tickets" type="button"><span class="icon"><i data-lucide="wand-sparkles"></i></span><span>Generate portfolio</span></button><button class="button is-outlined" id="copy-share" type="button"><span class="icon"><i data-lucide="link"></i></span><span>Copy link</span></button><button class="button is-outlined" id="download-tickets" type="button"><span class="icon"><i data-lucide="download"></i></span><span>CSV</span></button></div>
             <div class="notification" id="mode-disclaimer">Coverage changes portfolio overlap, not the probability of an individual combination.</div>
           </div></div>
           <div class="column">
             <div class="columns is-multiline">
-              <div class="column is-one-third"><div class="box"><p class="heading">Unique numbers</p><p class="title is-5" id="coverage-unique">—</p><p class="help">out of 45</p></div></div>
-              <div class="column is-one-third"><div class="box"><p class="heading">Max game overlap</p><p class="title is-5" id="coverage-overlap">—</p><p class="help">shared numbers</p></div></div>
-              <div class="column is-one-third"><div class="box"><p class="heading">Triple efficiency</p><p class="title is-5" id="coverage-triples">—</p><p class="help">unique / placed</p></div></div>
-              <div class="column is-one-third"><div class="box"><p class="heading">Quad efficiency</p><p class="title is-5" id="coverage-quads">—</p><p class="help">unique / placed</p></div></div>
-              <div class="column is-one-third"><div class="box"><p class="heading">Div 1 chance</p><p class="title is-5" id="coverage-probability">—</p><p class="help">same for any distinct set</p></div></div>
-              <div class="column is-one-third"><div class="box"><p class="heading">Simulated any-prize</p><p class="title is-5" id="coverage-any-prize">—</p><p class="help" id="coverage-any-prize-ci">local estimate</p></div></div>
+              <div class="column is-one-third-desktop is-half-tablet"><div class="box is-shadowless"><p class="heading">Unique numbers</p><p class="title is-5" id="coverage-unique">—</p><p class="help">out of 45</p></div></div>
+              <div class="column is-one-third-desktop is-half-tablet"><div class="box is-shadowless"><p class="heading">Max game overlap</p><p class="title is-5" id="coverage-overlap">—</p><p class="help">shared numbers</p></div></div>
+              <div class="column is-one-third-desktop is-half-tablet"><div class="box is-shadowless"><p class="heading">Triple efficiency</p><p class="title is-5" id="coverage-triples">—</p><p class="help">unique / placed</p></div></div>
+              <div class="column is-one-third-desktop is-half-tablet"><div class="box is-shadowless"><p class="heading">Quad efficiency</p><p class="title is-5" id="coverage-quads">—</p><p class="help">unique / placed</p></div></div>
+              <div class="column is-one-third-desktop is-half-tablet"><div class="box is-shadowless"><p class="heading">Div 1 chance</p><p class="title is-5" id="coverage-probability">—</p><p class="help">same for any distinct set</p></div></div>
+              <div class="column is-one-third-desktop is-half-tablet"><div class="box is-shadowless"><p class="heading">Simulated any-prize</p><p class="title is-5" id="coverage-any-prize">—</p><p class="help" id="coverage-any-prize-ci">local estimate</p></div></div>
             </div>
-            <div class="box">
+            <div class="box is-shadowless">
               <div class="level is-mobile"><div class="level-left"><span>Pair coverage</span></div><div class="level-right"><strong id="pair-coverage-label">—</strong></div></div><progress id="pair-coverage-meter" class="progress is-primary" value="0" max="100">0%</progress>
               <div class="level is-mobile"><div class="level-left"><span>Triple coverage</span></div><div class="level-right"><strong id="triple-coverage-label">—</strong></div></div><progress id="triple-coverage-meter" class="progress is-info" value="0" max="100">0%</progress>
               <div class="level is-mobile"><div class="level-left"><span>Quadruple coverage</span></div><div class="level-right"><strong id="quad-coverage-label">—</strong></div></div><progress id="quad-coverage-meter" class="progress is-success" value="0" max="100">0%</progress>
             </div>
-            <div id="ticket-grid" class="columns is-multiline mx-0" aria-live="polite"><div class="column is-half"><div class="box is-skeleton">Loading portfolio</div></div><div class="column is-half"><div class="box is-skeleton">Loading portfolio</div></div></div>
+            <div id="ticket-grid" class="columns is-multiline mx-0" aria-live="polite"><div class="column is-half"><div class="box is-shadowless is-skeleton">Loading portfolio</div></div><div class="column is-half"><div class="box is-shadowless is-skeleton">Loading portfolio</div></div></div>
           </div>
         </div>
       </div>
@@ -137,58 +137,58 @@
 
     <section class="section py-5" id="evidence">
       <div class="container">
-        <div class="mb-5"><p class="tag is-link is-light">Evidence</p><h2 class="title is-3 mt-3">Exact results and benchmark evidence</h2><p class="subtitle is-5">Reference simulations and walk-forward checks remain visible; exact portfolio results live in Benchmarks.</p></div>
+        <div class="mb-5"><span class="tag is-link">Evidence</span><h2 class="title is-3 mt-3">Exact results and benchmark evidence</h2><p class="subtitle is-5">Reference simulations and walk-forward checks remain visible; exact portfolio results live in Benchmarks.</p></div>
         <div class="columns">
-          <div class="column"><div class="box"><div class="level"><div class="level-left"><h3 class="title is-5">Coverage vs seeded QuickPick</h3></div><div class="level-right"><span class="tag" id="sim-trials">— trials</span></div></div><p class="heading">Coverage any prize</p><p class="title is-5" id="sim-coverage-any">—</p><progress id="sim-coverage-bar" class="progress is-primary" value="0" max="100">0%</progress><p class="help mb-4" id="sim-coverage-ci">—</p><p class="heading">QuickPick any prize</p><p class="title is-5" id="sim-random-any">—</p><progress id="sim-random-bar" class="progress is-info" value="0" max="100">0%</progress><p class="help" id="sim-random-ci">—</p></div></div>
-          <div class="column"><div class="box"><div class="level"><div class="level-left"><h3 class="title is-5">Recent out-of-sample draws</h3></div><div class="level-right"><span class="tag" id="backtest-steps">— draws</span></div></div><div id="backtest-table"><div class="skeleton-lines"><div></div><div></div><div></div></div></div></div></div>
+          <div class="column"><div class="box is-shadowless"><div class="level"><div class="level-left"><h3 class="title is-5">Coverage vs seeded QuickPick</h3></div><div class="level-right"><span class="tag" id="sim-trials">— trials</span></div></div><p class="heading">Coverage any prize</p><p class="title is-5" id="sim-coverage-any">—</p><progress id="sim-coverage-bar" class="progress is-primary" value="0" max="100">0%</progress><p class="help mb-4" id="sim-coverage-ci">—</p><p class="heading">QuickPick any prize</p><p class="title is-5" id="sim-random-any">—</p><progress id="sim-random-bar" class="progress is-info" value="0" max="100">0%</progress><p class="help" id="sim-random-ci">—</p></div></div>
+          <div class="column"><div class="box is-shadowless"><div class="level"><div class="level-left"><h3 class="title is-5">Recent out-of-sample draws</h3></div><div class="level-right"><span class="tag" id="backtest-steps">— draws</span></div></div><div id="backtest-table"><div class="skeleton-lines"><div></div><div></div><div></div></div></div></div></div>
         </div>
-        <article class="message is-info"><div class="message-header"><p><span class="icon"><i data-lucide="users"></i></span> Anti-crowding</p></div><div class="message-body">Potential prize sharing is a different question from winning probability. Human selections cluster around birthdays and familiar patterns, but the current anti-crowding score remains experimental and is not Australia-calibrated.</div></article>
+        <article class="message"><div class="message-header"><p><span class="icon"><i data-lucide="users"></i></span> Anti-crowding</p></div><div class="message-body">Potential prize sharing is a different question from winning probability. Human selections cluster around birthdays and familiar patterns, but the current anti-crowding score remains experimental and is not Australia-calibrated.</div></article>
       </div>
     </section>
 
     <section class="section py-5" id="draws">
       <div class="container">
-        <div class="mb-5"><p class="tag is-info is-light">History</p><h2 class="title is-3 mt-3">Browse past draws</h2><p class="subtitle is-5">Filter the validated historical record. These data are for exploration and auditing, not predictive weighting.</p></div>
-        <div class="box">
+        <div class="mb-5"><span class="tag is-info">History</span><h2 class="title is-3 mt-3">Browse past draws</h2><p class="subtitle is-5">Filter the validated historical record. These data are for exploration and auditing, not predictive weighting.</p></div>
+        <div class="box is-shadowless">
           <div class="columns is-multiline">
-            <div class="column is-one-third"><div class="field"><label class="label" for="draw-search">Search</label><div class="control has-icons-left"><input id="draw-search" class="input" type="search" placeholder="Date or number…" autocomplete="off"><span class="icon is-left"><i data-lucide="search"></i></span></div></div></div>
+            <div class="column is-full-mobile is-one-third-tablet"><div class="field"><label class="label" for="draw-search">Search</label><div class="control has-icons-left"><input id="draw-search" class="input" type="search" placeholder="Date or number…" autocomplete="off"><span class="icon is-left"><i data-lucide="search"></i></span></div></div></div>
             <div class="column"><div class="field"><label class="label" for="draw-from">From</label><div class="control"><input id="draw-from" class="input" type="date"></div></div></div>
             <div class="column"><div class="field"><label class="label" for="draw-to">To</label><div class="control"><input id="draw-to" class="input" type="date"></div></div></div>
             <div class="column"><div class="field"><label class="label" for="draw-number">Contains</label><div class="control"><div class="select is-fullwidth"><select id="draw-number"><option value="">Any</option></select></div></div></div></div>
           </div>
-          <div class="buttons"><button class="button is-light" id="reset-draw-filters" type="button"><span class="icon"><i data-lucide="rotate-ccw"></i></span><span>Reset</span></button><button class="button is-light" id="download-draws" type="button"><span class="icon"><i data-lucide="download"></i></span><span>Export CSV</span></button></div>
+          <div class="buttons is-flex-wrap-wrap"><button class="button is-outlined" id="reset-draw-filters" type="button"><span class="icon"><i data-lucide="rotate-ccw"></i></span><span>Reset</span></button><button class="button is-outlined" id="download-draws" type="button"><span class="icon"><i data-lucide="download"></i></span><span>Export CSV</span></button></div>
           <p class="mb-4"><strong id="draw-result-count">—</strong> matching draws</p>
           <div id="draw-list" aria-live="polite"><div class="skeleton-lines"><div></div><div></div><div></div><div></div></div></div>
-          <button class="button is-light mt-4" id="load-more-draws" type="button">Show more</button>
+          <button class="button is-outlined mt-4" id="load-more-draws" type="button">Show more</button>
         </div>
       </div>
     </section>
 
     <section class="section py-5" id="diagnostics">
       <div class="container">
-        <div class="mb-5"><p class="tag is-warning is-light">Diagnostics</p><h2 class="title is-3 mt-3">Inspect the historical distribution</h2><p class="subtitle is-5">These views describe past variation and are isolated from ticket generation.</p></div>
+        <div class="mb-5"><span class="tag is-warning">Diagnostics</span><h2 class="title is-3 mt-3">Inspect the historical distribution</h2><p class="subtitle is-5">These views describe past variation and are isolated from ticket generation.</p></div>
         <div class="tabs is-boxed is-small"><ul><li class="is-active"><a href="#panel-frequency" data-tab="frequency"><span class="icon is-hidden-mobile"><i data-lucide="bar-chart-3"></i></span><span>Frequency</span></a></li><li><a href="#panel-pairs" data-tab="pairs"><span class="icon is-hidden-mobile"><i data-lucide="waypoints"></i></span><span>Pairs</span></a></li><li><a href="#panel-quality" data-tab="quality"><span class="icon is-hidden-mobile"><i data-lucide="shield-check"></i></span><span>Quality</span></a></li></ul></div>
-        <div class="box" id="panel-frequency"><h3 class="title is-5">Main-number appearances</h3><div id="frequency-chart" aria-label="Historical main-number frequency table"><div class="skeleton-lines"><div></div><div></div><div></div></div></div><p class="help" id="chart-live" aria-live="polite"></p></div>
-        <div class="box is-hidden" id="panel-pairs"><h3 class="title is-5">Most common historical pairs</h3><div id="pair-grid" class="columns is-multiline"><div class="column"><div class="box is-skeleton">Loading pairs</div></div></div></div>
-        <div class="box is-hidden" id="panel-quality"><div class="columns is-multiline"><div class="column is-one-quarter"><p class="heading">Stats generated</p><p class="title is-6" id="quality-generated">—</p></div><div class="column is-one-quarter"><p class="heading">χ² vs equal counts</p><p class="title is-6" id="quality-chi">—</p></div><div class="column is-one-quarter"><p class="heading">Main observations</p><p class="title is-6" id="quality-main">—</p></div><div class="column is-one-quarter"><p class="heading">Secondary verification</p><p class="title is-6" id="quality-secondary">—</p></div></div><div class="content"><p><strong>Winning CSV SHA-256</strong><br><code id="hash-winning">—</code></p><p><strong>Supplementary CSV SHA-256</strong><br><code id="hash-supp">—</code></p></div><div class="notification is-warning is-light" id="data-warning" hidden></div></div>
+        <div class="box is-shadowless" id="panel-frequency"><h3 class="title is-5">Main-number appearances</h3><div id="frequency-chart" aria-label="Historical main-number frequency table"><div class="skeleton-lines"><div></div><div></div><div></div></div></div><p class="help" id="chart-live" aria-live="polite"></p></div>
+        <div class="box is-shadowless is-hidden" id="panel-pairs"><h3 class="title is-5">Most common historical pairs</h3><div id="pair-grid" class="columns is-multiline"><div class="column"><div class="box is-shadowless is-skeleton">Loading pairs</div></div></div></div>
+        <div class="box is-shadowless is-hidden" id="panel-quality"><div class="columns is-multiline"><div class="column is-half-tablet is-one-quarter-desktop"><p class="heading">Stats generated</p><p class="title is-6" id="quality-generated">—</p></div><div class="column is-half-tablet is-one-quarter-desktop"><p class="heading">χ² vs equal counts</p><p class="title is-6" id="quality-chi">—</p></div><div class="column is-half-tablet is-one-quarter-desktop"><p class="heading">Main observations</p><p class="title is-6" id="quality-main">—</p></div><div class="column is-half-tablet is-one-quarter-desktop"><p class="heading">Secondary verification</p><p class="title is-6" id="quality-secondary">—</p></div></div><div class="content"><p><strong>Winning CSV SHA-256</strong><br><code id="hash-winning">—</code></p><p><strong>Supplementary CSV SHA-256</strong><br><code id="hash-supp">—</code></p></div><div class="notification is-warning" id="data-warning" hidden></div></div>
       </div>
     </section>
 
     <section class="section py-5" id="method">
       <div class="container">
-        <div class="mb-5"><p class="tag is-dark is-light">Method</p><h2 class="title is-3 mt-3">What each result means</h2><p class="subtitle is-5">Exact mathematics, simulation, historical description and experimental ideas are kept separate.</p></div>
+        <div class="mb-5"><span class="tag">Method</span><h2 class="title is-3 mt-3">What each result means</h2><p class="subtitle is-5">Exact mathematics, simulation, historical description and experimental ideas are kept separate.</p></div>
         <div class="columns is-multiline">
-          <div class="column is-one-third"><div class="box"><span class="tag is-success is-light">Exact</span><h3 class="title is-5 mt-3">Combination probability</h3><p>C(45,6) defines the standard-game Division 1 sample space.</p></div></div>
-          <div class="column is-one-third"><div class="box"><span class="tag is-success is-light">Exact</span><h3 class="title is-5 mt-3">Subset coverage</h3><p>Pair, triple and quadruple coverage is counted directly.</p></div></div>
-          <div class="column is-one-third"><div class="box"><span class="tag is-info is-light">Simulated</span><h3 class="title is-5 mt-3">Portfolio outcomes</h3><p>Monte Carlo estimates unresolved lower-division portfolio behaviour.</p></div></div>
-          <div class="column is-one-third"><div class="box"><span class="tag is-light">Descriptive</span><h3 class="title is-5 mt-3">Historical diagnostics</h3><p>Frequency, pairs, entropy and z-scores inspect past variation only.</p></div></div>
-          <div class="column is-one-third"><div class="box"><span class="tag is-warning is-light">Experimental</span><h3 class="title is-5 mt-3">Anti-crowding</h3><p>Human-choice research may inform conditional prize-sharing risk.</p></div></div>
-          <div class="column is-one-third"><div class="box"><span class="tag is-danger is-light">Guardrail</span><h3 class="title is-5 mt-3">No predictive scoring</h3><p>No hot, cold, due, recency or ML score is presented as a next-draw probability edge.</p></div></div>
+          <div class="column is-half-tablet is-one-third-desktop"><div class="box is-shadowless"><span class="tag is-success">Exact</span><h3 class="title is-5 mt-3">Combination probability</h3><p>C(45,6) defines the standard-game Division 1 sample space.</p></div></div>
+          <div class="column is-half-tablet is-one-third-desktop"><div class="box is-shadowless"><span class="tag is-success">Exact</span><h3 class="title is-5 mt-3">Subset coverage</h3><p>Pair, triple and quadruple coverage is counted directly.</p></div></div>
+          <div class="column is-half-tablet is-one-third-desktop"><div class="box is-shadowless"><span class="tag is-info">Simulated</span><h3 class="title is-5 mt-3">Portfolio outcomes</h3><p>Monte Carlo estimates unresolved lower-division portfolio behaviour.</p></div></div>
+          <div class="column is-half-tablet is-one-third-desktop"><div class="box is-shadowless"><span class="tag">Descriptive</span><h3 class="title is-5 mt-3">Historical diagnostics</h3><p>Frequency, pairs, entropy and z-scores inspect past variation only.</p></div></div>
+          <div class="column is-half-tablet is-one-third-desktop"><div class="box is-shadowless"><span class="tag is-warning">Experimental</span><h3 class="title is-5 mt-3">Anti-crowding</h3><p>Human-choice research may inform conditional prize-sharing risk.</p></div></div>
+          <div class="column is-half-tablet is-one-third-desktop"><div class="box is-shadowless"><span class="tag is-danger">Guardrail</span><h3 class="title is-5 mt-3">No predictive scoring</h3><p>No hot, cold, due, recency or ML score is presented as a next-draw probability edge.</p></div></div>
         </div>
       </div>
     </section>
 
-    <section class="section py-5"><div class="container"><div id="toast" class="notification is-info is-light is-hidden" role="status" aria-live="polite"></div></div></section>
+    <section class="section py-5"><div class="container"><div id="toast" class="notification is-info is-hidden" role="status" aria-live="polite"></div></div></section>
   </main>
 
   <footer class="footer"><div class="content has-text-centered"><p><strong>Lottery Lab</strong> · Open-source probability and data-quality tooling. Not affiliated with The Lott.</p><p><a href="games.html">Games &amp; odds</a> · <a href="benchmark.html">Benchmarks</a> · <a href="https://github.com/JDsnyke/saturday-tatts-lotto-scraper">GitHub</a> · <a href="https://github.com/JDsnyke/saturday-tatts-lotto-scraper/blob/main/docs/METHODOLOGY.md">Method</a></p><p class="is-size-7">Lottery products involve financial risk. More entries increase spend as well as probability.</p></div></footer>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "australian-lottery-lab-site",
+  "private": true,
+  "version": "3.0.0",
+  "description": "Static web dependencies for Lottery Lab",
+  "engines": {
+    "node": ">=22"
+  },
+  "dependencies": {
+    "bulma": "1.0.4",
+    "lucide": "1.33.0"
+  }
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,11 +1,11 @@
-const CACHE_NAME = 'australian-lottery-lab-bulma-v2';
-const BULMA_URL = 'https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css';
-const LUCIDE_URL = 'https://unpkg.com/lucide@1.33.0/dist/umd/lucide.js';
+const CACHE_NAME = 'australian-lottery-lab-bulma-v3';
 const STATIC_ASSETS = [
   './',
   './index.html',
   './benchmark.html',
   './games.html',
+  './assets/vendor/bulma.min.css',
+  './assets/vendor/lucide.js',
   './assets/ui.js',
   './assets/app.js',
   './assets/benchmark.js',
@@ -16,8 +16,6 @@ const STATIC_ASSETS = [
   './assets/lotto_stats.json',
   './assets/data_provenance.json',
   './assets/game_catalog.json',
-  BULMA_URL,
-  LUCIDE_URL,
 ];
 
 self.addEventListener('install', event => {
@@ -39,11 +37,9 @@ self.addEventListener('activate', event => {
 self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
   const url = new URL(event.request.url);
-  const isLocal = url.origin === self.location.origin;
-  const isLibrary = event.request.url === BULMA_URL || event.request.url === LUCIDE_URL;
-  if (!isLocal && !isLibrary) return;
+  if (url.origin !== self.location.origin) return;
 
-  const isData = isLocal && (
+  const isData = (
     url.pathname.endsWith('/assets/lotto_stats.json') ||
     url.pathname.endsWith('/assets/data_provenance.json') ||
     url.pathname.endsWith('/assets/game_catalog.json')
@@ -51,21 +47,27 @@ self.addEventListener('fetch', event => {
 
   if (isData) {
     event.respondWith(
-      fetch(event.request)
+      fetch(event.request, { cache: 'no-store' })
         .then(response => {
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
           const copy = response.clone();
           caches.open(CACHE_NAME).then(cache => cache.put(event.request, copy));
           return response;
         })
-        .catch(() => caches.match(event.request))
+        .catch(async () => {
+          const cached = await caches.match(event.request);
+          return cached || Response.error();
+        })
     );
     return;
   }
 
   event.respondWith(
     caches.match(event.request).then(cached => cached || fetch(event.request).then(response => {
-      const copy = response.clone();
-      caches.open(CACHE_NAME).then(cache => cache.put(event.request, copy));
+      if (response.ok) {
+        const copy = response.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, copy));
+      }
       return response;
     }))
   );

--- a/tests/test_benchmark_site.py
+++ b/tests/test_benchmark_site.py
@@ -17,8 +17,10 @@ class BenchmarkSiteTests(unittest.TestCase):
             "benchmark.html",
         ):
             self.assertTrue((ROOT / path).exists(), path)
-        self.assertIn("bulma@1.0.4/css/bulma.min.css", html)
-        self.assertIn("lucide@1.33.0/dist/umd/lucide.js", html)
+        self.assertIn("assets/vendor/bulma.min.css", html)
+        self.assertIn("assets/vendor/lucide.js", html)
+        self.assertNotIn("cdn.jsdelivr.net", html)
+        self.assertNotIn("unpkg.com", html)
         self.assertNotIn("assets/benchmark.css", html)
         self.assertIn("assets/ui.js", html)
         self.assertIn("assets/benchmark.js", html)
@@ -41,6 +43,12 @@ class BenchmarkSiteTests(unittest.TestCase):
         self.assertIn('id="cert-overlap"', html)
         self.assertIn('id="portfolio-benchmark"', html)
         self.assertIn('id="benchmark-progress"', html)
+
+    def test_static_benchmark_surfaces_are_shadowless_and_theme_safe(self):
+        html = (ROOT / "benchmark.html").read_text(encoding="utf-8")
+        self.assertIn("box is-shadowless", html)
+        self.assertNotIn(" is-light", html)
+        self.assertNotIn("has-shadow", html)
 
 
 if __name__ == "__main__":

--- a/tests/test_games_site_v3.py
+++ b/tests/test_games_site_v3.py
@@ -12,13 +12,16 @@ class GamesSiteTests(unittest.TestCase):
             "assets/ui.js",
             "assets/games.js",
             "assets/game_catalog.json",
+            "package.json",
         ):
             self.assertTrue((ROOT / relative).exists(), relative)
 
-    def test_games_page_references_library_assets_and_calculators(self):
+    def test_games_page_references_local_library_assets_and_calculators(self):
         page = (ROOT / "games.html").read_text(encoding="utf-8")
-        self.assertIn("bulma@1.0.4/css/bulma.min.css", page)
-        self.assertIn("lucide@1.33.0/dist/umd/lucide.js", page)
+        self.assertIn("assets/vendor/bulma.min.css", page)
+        self.assertIn("assets/vendor/lucide.js", page)
+        self.assertNotIn("cdn.jsdelivr.net", page)
+        self.assertNotIn("unpkg.com", page)
         self.assertIn("assets/ui.js", page)
         self.assertIn("assets/games.js", page)
         self.assertNotIn("assets/games.css", page)
@@ -64,6 +67,12 @@ class GamesSiteTests(unittest.TestCase):
         ):
             self.assertIn(slug, slugs)
 
+    def test_dynamic_cards_are_shadowless_and_not_light_forced(self):
+        script = (ROOT / "assets/games.js").read_text(encoding="utf-8")
+        self.assertIn('card is-shadowless', script)
+        self.assertNotIn("is-success' : 'is-warning'} is-light", script)
+        self.assertNotIn('button is-small is-link is-light', script)
+
     def test_catalog_public_guardrails(self):
         payload = json.loads((ROOT / "assets/game_catalog.json").read_text(encoding="utf-8"))
         rows = {row["slug"]: row for row in payload["games"]}
@@ -73,12 +82,9 @@ class GamesSiteTests(unittest.TestCase):
         self.assertIsNone(rows["weekday-windfall"]["officialAnyOdds"])
         self.assertIsNone(rows["lucky-lotteries-super"]["officialAnyOdds"])
         self.assertIsNone(rows["yourtown-prize-home"]["computedTopOdds"])
-        self.assertEqual(
-            rows["mater-prize-home"]["raffleSnapshot"]["maximumEntries"],
-            22_805_334,
-        )
+        self.assertEqual(rows["mater-prize-home"]["raffleSnapshot"]["maximumEntries"], 22_805_334)
 
-    def test_pwa_exposes_games_lab_and_library_dependencies(self):
+    def test_pwa_exposes_games_lab_and_local_library_dependencies(self):
         manifest = json.loads((ROOT / "assets/site.webmanifest").read_text(encoding="utf-8"))
         shortcut_urls = {shortcut["url"] for shortcut in manifest["shortcuts"]}
         self.assertIn("../games.html", shortcut_urls)
@@ -88,9 +94,11 @@ class GamesSiteTests(unittest.TestCase):
         self.assertIn("./assets/ui.js", worker)
         self.assertIn("./assets/games.js", worker)
         self.assertIn("./assets/game_catalog.json", worker)
-        self.assertIn("bulma@1.0.4/css/bulma.min.css", worker)
-        self.assertIn("lucide@1.33.0/dist/umd/lucide.js", worker)
-        self.assertIn("australian-lottery-lab-bulma-v2", worker)
+        self.assertIn("./assets/vendor/bulma.min.css", worker)
+        self.assertIn("./assets/vendor/lucide.js", worker)
+        self.assertIn("australian-lottery-lab-bulma-v3", worker)
+        self.assertNotIn("cdn.jsdelivr.net", worker)
+        self.assertNotIn("unpkg.com", worker)
 
 
 if __name__ == "__main__":

--- a/tests/test_static_site.py
+++ b/tests/test_static_site.py
@@ -1,23 +1,25 @@
+import json
 import re
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 PAGES = ("index.html", "games.html", "benchmark.html")
-BULMA = "https://cdn.jsdelivr.net/npm/bulma@1.0.4/css/bulma.min.css"
-LUCIDE = "https://unpkg.com/lucide@1.33.0/dist/umd/lucide.js"
+BULMA = "assets/vendor/bulma.min.css"
+LUCIDE = "assets/vendor/lucide.js"
 
 
 class StaticSiteTests(unittest.TestCase):
     def test_browser_assets_and_pwa_references_exist(self):
         html = (ROOT / "index.html").read_text(encoding="utf-8")
-        js = (ROOT / "assets/app.js").read_text(encoding="utf-8")
         for path in (
             "assets/ui.js",
             "assets/app.js",
             "assets/site.webmanifest",
             "assets/data_provenance.json",
             "service-worker.js",
+            "package.json",
+            ".github/scripts/prepare_site.sh",
         ):
             self.assertTrue((ROOT / path).exists(), path)
         self.assertIn(BULMA, html)
@@ -25,13 +27,17 @@ class StaticSiteTests(unittest.TestCase):
         self.assertIn("assets/ui.js", html)
         self.assertIn("assets/app.js", html)
         self.assertIn("assets/site.webmanifest", html)
-        self.assertIn("service-worker.js", js)
 
-    def test_all_pages_use_pinned_bulma_and_lucide(self):
+    def test_all_pages_use_local_pinned_bulma_and_lucide(self):
+        package = json.loads((ROOT / "package.json").read_text(encoding="utf-8"))
+        self.assertEqual(package["dependencies"]["bulma"], "1.0.4")
+        self.assertEqual(package["dependencies"]["lucide"], "1.33.0")
         for name in PAGES:
             html = (ROOT / name).read_text(encoding="utf-8")
             self.assertIn(BULMA, html, name)
             self.assertIn(LUCIDE, html, name)
+            self.assertNotIn("cdn.jsdelivr.net", html, name)
+            self.assertNotIn("unpkg.com", html, name)
             self.assertIn("assets/ui.js", html, name)
             self.assertIn("data-lucide=", html, name)
 
@@ -69,6 +75,29 @@ class StaticSiteTests(unittest.TestCase):
         ):
             pattern = rf'class=["\'][^"\']*\b{re.escape(legacy_class)}\b'
             self.assertIsNone(re.search(pattern, content), legacy_class)
+
+    def test_publication_build_vendors_dependencies(self):
+        script = (ROOT / ".github/scripts/prepare_site.sh").read_text(encoding="utf-8")
+        self.assertIn("node_modules/bulma/css/bulma.min.css", script)
+        self.assertIn("node_modules/lucide/dist/umd/lucide.js", script)
+        self.assertIn("_site/assets/vendor/bulma.min.css", script)
+        self.assertIn("_site/assets/vendor/lucide.js", script)
+
+    def test_pages_deploy_regenerates_canonical_stats_before_upload(self):
+        workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+        self.assertIn("python -m lotto_lab stats", workflow)
+        self.assertIn("bash .github/scripts/prepare_site.sh", workflow)
+        self.assertIn("path: '_site'", workflow)
+        self.assertIn("stats.get('schemaVersion') == 3", workflow)
+        self.assertIn("stats.get('draws')", workflow)
+
+    def test_service_worker_has_no_cross_origin_install_dependency(self):
+        worker = (ROOT / "service-worker.js").read_text(encoding="utf-8")
+        self.assertIn("australian-lottery-lab-bulma-v3", worker)
+        self.assertIn("./assets/vendor/bulma.min.css", worker)
+        self.assertIn("./assets/vendor/lucide.js", worker)
+        self.assertNotIn("cdn.jsdelivr.net", worker)
+        self.assertNotIn("unpkg.com", worker)
 
     def test_direct_javascript_id_references_exist_in_html(self):
         html = (ROOT / "index.html").read_text(encoding="utf-8")

--- a/tests/test_ui_redesign.py
+++ b/tests/test_ui_redesign.py
@@ -13,7 +13,7 @@ class UiRedesignTests(unittest.TestCase):
 
     def test_bulma_features_are_used_directly(self):
         pages = "\n".join((ROOT / name).read_text(encoding="utf-8") for name in PAGES)
-        self.assertIn("bulma@1.0.4/css/bulma.min.css", pages)
+        self.assertIn("assets/vendor/bulma.min.css", pages)
         self.assertIn("navbar", pages)
         self.assertIn("hero", pages)
         self.assertIn("columns", pages)
@@ -23,21 +23,31 @@ class UiRedesignTests(unittest.TestCase):
         self.assertIn("is-skeleton", pages)
         self.assertIn("skeleton-lines", pages)
 
-    def test_theme_switcher_uses_bulma_data_theme_contract(self):
+    def test_theme_switcher_resolves_system_to_explicit_bulma_theme(self):
         script = (ROOT / "assets/ui.js").read_text(encoding="utf-8")
-        self.assertIn("setAttribute('data-theme', value)", script)
-        self.assertIn("removeAttribute('data-theme')", script)
+        self.assertIn("setAttribute('data-theme', resolvedTheme)", script)
+        self.assertIn("data-theme-preference", script)
         self.assertIn("['system', 'light', 'dark']", script)
+        self.assertIn("prefers-color-scheme: dark", script)
+        self.assertIn("MutationObserver", script)
+        self.assertIn("is-shadowless", script)
         self.assertNotIn("style.", script)
 
-    def test_lucide_is_the_icon_system(self):
+    def test_lucide_is_local_and_the_icon_system(self):
         pages = "\n".join((ROOT / name).read_text(encoding="utf-8") for name in PAGES)
         script = (ROOT / "assets/ui.js").read_text(encoding="utf-8")
-        self.assertIn("lucide@1.33.0/dist/umd/lucide.js", pages)
+        self.assertIn("assets/vendor/lucide.js", pages)
+        self.assertNotIn("unpkg.com", pages)
         self.assertIn("data-lucide=", pages)
         self.assertIn("lucide.createIcons", script)
         for symbol in ("◐", "Δ", "Σ", "✓"):
             self.assertNotIn(symbol, pages)
+
+    def test_static_pages_do_not_force_light_variants_or_shadows(self):
+        pages = "\n".join((ROOT / name).read_text(encoding="utf-8") for name in PAGES)
+        self.assertNotIn(" is-light", pages)
+        self.assertNotIn("has-shadow", pages)
+        self.assertIn("is-shadowless", pages)
 
     def test_old_generated_homepage_slogans_are_removed(self):
         pages = "\n".join((ROOT / name).read_text(encoding="utf-8") for name in PAGES)
@@ -49,13 +59,24 @@ class UiRedesignTests(unittest.TestCase):
         ):
             self.assertNotIn(phrase, pages)
 
-    def test_pages_deployment_tracks_all_user_facing_surfaces(self):
+    def test_pages_deployment_builds_and_validates_publication_payload(self):
         workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
         for path in ("index.html", "benchmark.html", "games.html", "service-worker.js", "assets/**"):
             self.assertIn(path, workflow)
-        self.assertIn("Validate static site payload", workflow)
-        self.assertIn("test ! -f assets/app.css", workflow)
+        self.assertIn("Build self-contained site payload", workflow)
+        self.assertIn("Validate publication payload", workflow)
+        self.assertIn("test ! -f _site/assets/app.css", workflow)
         self.assertIn("! grep -R -n 'style='", workflow)
+        self.assertIn("schemaVersion", workflow)
+        self.assertIn("path: '_site'", workflow)
+
+    def test_browser_gate_checks_contrast_loading_and_mobile_menu(self):
+        script = (ROOT / ".github/scripts/browser_audit.mjs").read_text(encoding="utf-8")
+        self.assertIn("lowContrast", script)
+        self.assertIn("menuOverlap", script)
+        self.assertIn("visibleLegacyText", script)
+        self.assertIn("page-specific content did not finish loading", script)
+        self.assertIn("local Bulma stylesheet did not load", script)
 
     def test_pwa_metadata_matches_neutral_redesign(self):
         manifest = json.loads((ROOT / "assets/site.webmanifest").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Production hardening

This fixes the root causes behind the remaining broken dark mode and partially loaded site rather than masking them.

### Data / loading
- Pages regenerates canonical `schemaVersion: 3` Saturday stats before publication.
- Deployment rejects a payload without draw history or canonical v3 data.
- CI, UI browser testing, and Pages build the same `_site` payload.
- This closes the gap where CI regenerated good data in its runner but Pages uploaded the stale tracked pre-v3 JSON.
- The forced service-worker controller reload was removed because it could abort in-flight `data_provenance.json` requests.

### Self-contained static assets
- Bulma 1.0.4 and Lucide 1.33.0 are pinned in `package.json` and copied into the built site as `assets/vendor/bulma.min.css` and `assets/vendor/lucide.js`.
- Public HTML uses those local assets only; there are no runtime jsDelivr/unpkg dependencies.
- The service worker caches same-origin static assets only and has no cross-origin install dependency.
- PWA cache namespace is `australian-lottery-lab-bulma-v3`.

### Dark mode / layout
- all three pages resolve System/Light/Dark to an explicit Bulma `data-theme=light|dark` state;
- dynamic `is-light` variants are removed in dark mode and restored in light mode;
- problematic outlined secondary buttons are removed in dark mode and restored in light mode;
- low-contrast `is-selected` navbar styling is replaced with theme-safe active-page emphasis;
- all Bulma boxes/cards are `is-shadowless`, including dynamically inserted cards;
- navbar/menu items retain spacing helpers and full-width mobile theme controls;
- no inline presentation styles were added.

### Stronger browser acceptance gate
The Chromium gate checks all 12 page/viewport/theme combinations and now additionally:
- opens the mobile burger menu and rejects overlapping / undersized menu items;
- rejects sampled dark-theme text below 3:1 contrast;
- rejects visible box/card shadows;
- requires local Bulma and Lucide to load;
- rejects visible legacy-data messaging;
- requires real Saturday draw/history/diagnostic content to load;
- requires Games catalog cards to load;
- requires Benchmark certificates/reference evidence to finish loading;
- keeps skeleton, console-error, request-failure and horizontal-overflow checks.

### Final validation
On head `f786051594047fa95ebfe68cadc20e2ed8c615e0`:
- CI: success
- Multi-game catalog: success
- UI browser: success

The successful UI browser run includes the exact contrast and content-readiness assertions that failed the previous revision, so those regressions are now covered rather than merely visually assumed.